### PR TITLE
fix: review_requested通知の依頼人をsenderに変更

### DIFF
--- a/.github/discord-notify.js
+++ b/.github/discord-notify.js
@@ -129,8 +129,10 @@ module.exports = async ({ context, core, fs }) => {
       });
       if (!shouldNotify) return;
 
+      const requester = context.payload.sender?.login || pr.user.login;
+
       const msg = [
-        `${mentionOf(pr.user.login)}が${mentions}にレビューを依頼しました！`,
+        `${mentionOf(requester)}が${mentions}にレビューを依頼しました！`,
         `[**${pr.title}**](${pr.html_url})`,
       ].join('\n');
       await post(msg);


### PR DESCRIPTION
## 概要
Discord通知の pull_request / review_requested イベントで、依頼人としてPR作成者ではなく実際にレビュー依頼を実行したユーザー（context.payload.sender.login）を表示するように修正しました。

## 変更内容
- .github/discord-notify.js
  - review_requested 通知メッセージの依頼人を pr.user.login から context.payload.sender?.login に変更
  - sender が取得できない場合は従来どおり pr.user.login をフォールバック

## 期待される効果
- レビュー依頼通知の依頼人表示が実態と一致します。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
