### PR TITLE
fix: Discord merge notification wording and attribution

### DIFF
--- a/.github/discord-notify.js
+++ b/.github/discord-notify.js
@@ -153,8 +153,12 @@ module.exports = async ({ context, core, fs }) => {
       }
     } else if (action === 'closed' && pr.merged) {
       // 仕様: PRがmergeされたときに通知
+      const merger = pr.merged_by?.login || context.payload.sender?.login || '(unknown)';
+      const author = pr.user?.login || '(unknown)';
+      const mergerText = merger === '(unknown)' ? '(unknown)' : mentionOf(merger);
+      const authorText = author === '(unknown)' ? '(unknown)' : mentionOf(author);
       const msg = [
-        `✅ ${mentionOf(pr.user.login)}がプルリクをマージしました！`,
+        `✅ ${mergerText}が${authorText}のプルリクをマージしました！`,
         `[**${pr.title}**](${pr.html_url})`,
       ].join('\n');
       await post(msg);


### PR DESCRIPTION
## 概要
Discord通知のマージ時メッセージを修正しました。

## 変更内容
- マージ通知でPR作成者だけを表示していた問題を修正
- 通知文言を「（マージした人）が（作成者）のプルリクをマージしました！」へ変更
- merged_by / sender を使ってマージ実行者を特定
- unknown 表示時に不自然なメンションを避ける整形を追加

## 影響範囲
- .github/discord-notify.js の pull_request.closed（merged）通知のみ

## 動作確認
- 対象ファイルの構文エラーなしを確認

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
