### PR TITLE
feat: Cloud Run / Cloud SQL / Scheduler / Secret Manager リソースを追加

### DIFF
--- a/infra/main/cloudrun.tf
+++ b/infra/main/cloudrun.tf
@@ -1,0 +1,99 @@
+locals {
+  image_base = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}"
+}
+
+# API サーバー
+resource "google_cloud_run_v2_service" "server" {
+  name     = "server"
+  location = var.region
+
+  template {
+    service_account = google_service_account.cloudrun.email
+
+    containers {
+      image = "${local.image_base}/server:latest"
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+    }
+
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.main.connection_name]
+      }
+    }
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 3
+    }
+  }
+
+  # CI/CD がイメージを更新するため Terraform では image の変更を無視
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+    ]
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# 認証なしで外部からアクセスできるようにする（アプリ層で Firebase Auth が行う）
+resource "google_cloud_run_v2_service_iam_member" "server_public" {
+  project  = var.project_id
+  location = google_cloud_run_v2_service.server.location
+  name     = google_cloud_run_v2_service.server.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# Outbox バッチワーカー
+resource "google_cloud_run_v2_job" "worker" {
+  name     = "worker"
+  location = var.region
+
+  template {
+    template {
+      service_account = google_service_account.cloudrun.email
+
+      containers {
+        image = "${local.image_base}/worker:latest"
+
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+      }
+
+      volumes {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.main.connection_name]
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].template[0].containers[0].image,
+    ]
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+output "server_url" {
+  value = google_cloud_run_v2_service.server.uri
+}

--- a/infra/main/cloudsql.tf
+++ b/infra/main/cloudsql.tf
@@ -1,0 +1,61 @@
+resource "random_password" "db_password" {
+  length  = 32
+  special = false
+}
+
+resource "google_sql_database_instance" "main" {
+  name             = "main"
+  database_version = "POSTGRES_16"
+  region           = var.region
+
+  deletion_protection = false
+
+  settings {
+    tier              = "db-f1-micro" # 最安の共有コアインスタンス
+    availability_type = "ZONAL"       # シングルゾーン（HA なし）
+
+    disk_type       = "PD_HDD" # SSD より安価
+    disk_size       = 10       # 最小値（GB）
+    disk_autoresize = false    # 自動拡張を無効化してコスト管理
+
+    backup_configuration {
+      enabled = false # dev 環境はバックアップ不要
+    }
+
+    ip_configuration {
+      ipv4_enabled = true
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_sql_database" "app" {
+  name     = "app"
+  instance = google_sql_database_instance.main.name
+}
+
+resource "google_sql_user" "app" {
+  name     = "app"
+  instance = google_sql_database_instance.main.name
+  password = random_password.db_password.result
+}
+
+# DATABASE_URL を Secret Manager に保存
+resource "google_secret_manager_secret_version" "database_url" {
+  secret = google_secret_manager_secret.secrets["database-url"].id
+  secret_data = join("", [
+    "postgres://",
+    google_sql_user.app.name,
+    ":",
+    random_password.db_password.result,
+    "@/",
+    google_sql_database.app.name,
+    "?host=/cloudsql/",
+    google_sql_database_instance.main.connection_name,
+  ])
+}
+
+output "cloud_sql_connection_name" {
+  value = google_sql_database_instance.main.connection_name
+}

--- a/infra/main/scheduler.tf
+++ b/infra/main/scheduler.tf
@@ -1,0 +1,17 @@
+resource "google_cloud_scheduler_job" "worker" {
+  name      = "worker-trigger"
+  region    = var.region
+  schedule  = "*/20 * * * *"
+  time_zone = "Asia/Tokyo"
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.worker.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/infra/main/secret_manager.tf
+++ b/infra/main/secret_manager.tf
@@ -1,0 +1,24 @@
+locals {
+  secrets = [
+    "spotify-client-id",
+    "spotify-client-secret",
+    "apple-music-key-id",
+    "apple-music-team-id",
+    "apple-music-private-key",
+    "apns-key-id",
+    "apns-team-id",
+    "apns-private-key",
+    "database-url",
+  ]
+}
+
+resource "google_secret_manager_secret" "secrets" {
+  for_each  = toset(local.secrets)
+  secret_id = each.value
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}


### PR DESCRIPTION
一旦作っていますがしばらくはdraftにしておくつもりです
## Summary

- `cloudrun.tf`: Cloud Run service（server API）+ Cloud Run Job（worker）
- `cloudsql.tf`: Cloud SQL PostgreSQL インスタンス（db-f1-micro / HDD / 10GB / シングルゾーン）
- `scheduler.tf`: Cloud Scheduler（20分間隔で worker を起動）
- `secret_manager.tf`: Spotify / Apple Music / APNs / database-url シークレット枠

## 月額費用見積もり

| リソース | 月額概算 |
|---------|---------|
| Cloud SQL（db-f1-micro + 10GB HDD） | 約 $8.46 |
| その他（Cloud Run / Scheduler 等） | 約 $0 |
| **合計** | **約 $8.46 / 月** |

## マージ前に必要な対応

- [ ] Secret Manager の各シークレットに実際の値を投入
  ```
  gcloud secrets versions add spotify-client-id --data-file=-
  gcloud secrets versions add spotify-client-secret --data-file=-
  gcloud secrets versions add apple-music-key-id --data-file=-
  gcloud secrets versions add apple-music-team-id --data-file=-
  gcloud secrets versions add apple-music-private-key --data-file=-
  gcloud secrets versions add apns-key-id --data-file=-
  gcloud secrets versions add apns-team-id --data-file=-
  gcloud secrets versions add apns-private-key --data-file=-
  ```
- [ ] Docker イメージ（server / worker）を Artifact Registry にプッシュ済みであること

## Test plan

- [ ] `terraform plan` で想定通りのリソースが作成されることを確認してからマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
