### PR TITLE
fix: swaggo生成ブランチのAndroid CI失敗を解消

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.gitlab.arturbosch.detekt.Detekt
 import org.gradle.api.GradleException
 import java.util.Properties
 
@@ -180,6 +181,10 @@ dependencies {
 detekt {
     config.setFrom("$rootDir/detekt.yml")
     buildUponDefaultConfig = true
+}
+
+tasks.withType<Detekt>().configureEach {
+    exclude("**/generated/**")
 }
 
 ktlint {

--- a/android/app/src/main/java/com/digix00/musicswapping/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/digix00/musicswapping/di/NetworkModule.kt
@@ -3,7 +3,6 @@ package com.digix00.musicswapping.di
 import com.digix00.musicswapping.BuildConfig
 import com.digix00.musicswapping.data.remote.ApiService
 import com.digix00.musicswapping.data.remote.AuthInterceptor
-import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -14,6 +13,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 @Module
 @InstallIn(SingletonComponent::class)


### PR DESCRIPTION
### 変更サマリー
- chore/swaggo-code-generation で失敗していた Android CI（lint）を修正しました。
- NetworkModule.kt の import 順序を ktlint 準拠の辞書順へ修正しました。
- Detekt が生成コード（**/generated/**）を検査して失敗していたため、Detektタスク側にも除外設定を追加しました。
- 影響レイヤー: Android / CI設定（静的解析）

### テスト方法
- [x] 単体テスト（Kotlin: JUnit）
  - ndroid/ で ./gradlew.bat ktlintCheck detektDevDebug を実行し成功
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認（Spotify API / Apple Music API / Firebase Auth を含む場合）

### 考慮事項
- プライバシー: 該当なし
- セキュリティ: 該当なし
- 後方互換性: 生成コードの挙動は変更せず、静的解析対象のみ調整
- パフォーマンス: 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
