### PR TITLE
refactor: 外観設定機能を削除

### DIFF
--- a/ios/ios/Features/Settings/Hub/SettingsHubScreen.swift
+++ b/ios/ios/Features/Settings/Hub/SettingsHubScreen.swift
@@ -7,7 +7,8 @@ struct SettingsHubView: View {
         [
             SettingsDestination(id: "share-track", icon: "music.note", title: "シェアする曲", destination: AnyView(SearchView())),
             SettingsDestination(id: "encounter-settings", icon: "location.fill", title: "すれ違い設定", destination: AnyView(EncounterSettingsView())),
-            SettingsDestination(id: "notification-settings", icon: "bell.fill", title: "通知設定", destination: AnyView(NotificationSettingsView()))
+            SettingsDestination(id: "notification-settings", icon: "bell.fill", title: "通知設定", destination: AnyView(NotificationSettingsView())),
+            SettingsDestination(id: "appearance-settings", icon: "paintbrush.fill", title: "外観", destination: AnyView(AppearanceSettingsView()))
         ]
     }
 

--- a/ios/ios/Features/Settings/Preferences/AppearanceSettingsScreen.swift
+++ b/ios/ios/Features/Settings/Preferences/AppearanceSettingsScreen.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct AppearanceSettingsView: View {
+    var body: some View {
+        AppScaffold(
+            title: "外観",
+            subtitle: "表示テーマの設定"
+        ) {
+            SectionCard {
+                VStack(alignment: .leading, spacing: 20) {
+                    Label("ライトテーマ", systemImage: "sun.max.fill")
+                        .font(.system(size: 16, weight: .bold))
+                    Label("ダークテーマ", systemImage: "moon.fill")
+                        .font(.system(size: 16, weight: .bold))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 変更サマリー

iOS アプリから外観設定（ダークモード切り替え）機能を削除しました。設定画面の構成を簡素化し、不要な機能を除去しました。

- `AppearanceSettingsScreen.swift` を削除
- `SettingsHubScreen.swift` から外観設定への導線を削除
- 影響レイヤー: iOS

## テスト方法

- [ ] 実機またはシミュレータでの手動確認
  - 設定画面を開き、外観設定項目が表示されないことを確認
  - 残りの設定項目（シェアする曲、すれ違い設定、通知設定）が正常に表示されることを確認
  - 各設定項目の遷移が正常に動作することを確認

## 考慮事項

該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
