### PR TITLE
test: FK制約違反を防ぐため prefecture を user より先に INSERT

### DIFF
--- a/backend/internal/handler/router_test.go
+++ b/backend/internal/handler/router_test.go
@@ -326,6 +326,9 @@ func TestPatchAndDeletePushToken(t *testing.T) {
 
 func TestCreateGetPatchAndDeleteUserFlow(t *testing.T) {
 	db := newTestDB(t)
+	if err := db.Create(&model.Prefecture{ID: "13", Name: "東京都"}).Error; err != nil {
+		t.Fatalf("create prefecture: %v", err)
+	}
 	e := newTestServer(t, db, "firebase-uid-user-flow")
 
 	createReq, err := authRequest(http.MethodPost, "/api/v1/users", map[string]any{
@@ -513,6 +516,9 @@ func TestGetUserByIDMasksProfileAndTrack(t *testing.T) {
 	bio := "secret bio"
 	prefID := "13"
 	birthdate := jsonDate(t, "1998-03-10")
+	if err := db.Create(&model.Prefecture{ID: "13", Name: "東京都"}).Error; err != nil {
+		t.Fatalf("create prefecture: %v", err)
+	}
 	target := model.User{
 		ID:             uuid.NewString(),
 		AuthProvider:   testFirebaseProvider,
@@ -526,9 +532,6 @@ func TestGetUserByIDMasksProfileAndTrack(t *testing.T) {
 	}
 	if err := db.Create(&target).Error; err != nil {
 		t.Fatalf("create target user: %v", err)
-	}
-	if err := db.Create(&model.Prefecture{ID: "13", Name: "東京都"}).Error; err != nil {
-		t.Fatalf("create prefecture: %v", err)
 	}
 	settings := model.UserSettings{ID: uuid.NewString(), UserID: target.ID}
 	if err := db.Create(&settings).Error; err != nil {


### PR DESCRIPTION
## 変更サマリー

- `TestCreateGetPatchAndDeleteUserFlow` と `TestGetUserByIDMasksProfileAndTrack` で、`fk_users_prefecture` FK 制約違反によりテストが失敗していた
- `prefecture_id` を持つ `users` レコードを INSERT する前に、参照先の `prefectures` レコードを先に INSERT するよう順序を修正した
- 影響レイヤー: バックエンド / integration テスト

## テスト方法

- [x] `go test ./... -cover` でローカルの integration テストが通ることを確認

## 考慮事項

該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
