### PR TITLE
chore: Android CIの無効化

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,16 +1,7 @@
 name: Android CI
 
 on:
-  push:
-    branches: [ "main", "develop" ]
-    paths:
-      - "android/**"
-      - ".github/workflows/android.yml"
-  pull_request:
-    branches: [ "main", "develop" ]
-    paths:
-      - "android/**"
-      - ".github/workflows/android.yml"
+  workflow_dispatch: # Android 開発一時中断のため、手動実行のみに変更
 
 defaults:
   run:


### PR DESCRIPTION
## 変更サマリー

Androidの開発を一旦停止するため、関連するCIワークフローを無効化しました。
- \.github/workflows/android.yml\ の各ジョブに \if: false\ を追加し、実行をスキップするように変更。
- \ackend/Makefile\ の \generate-code\ ターゲットから Android クライアント生成を削除し、\codegen-check\ での Android 関連チェックを無効化。
- 影響レイヤー: CI/CD / 開発環境

## テスト方法

- [ ] GitHub Actions 上で各ワークフローが期待通りスキップされることの確認（マージ後またはPR実行時）

## 考慮事項

- 今後 Android 開発を再開する際には、これらの変更を元に戻す必要があります。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
