### PR TITLE
refactor: TransactorインターフェースをuseCase/portからdomain/repositoryへ移動

### DIFF
--- a/backend/internal/domain/repository/tx.go
+++ b/backend/internal/domain/repository/tx.go
@@ -1,4 +1,4 @@
-package port
+package repository
 
 import "context"
 

--- a/backend/internal/infra/rdb/tx.go
+++ b/backend/internal/infra/rdb/tx.go
@@ -5,7 +5,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"hackathon/internal/usecase/port"
+	"hackathon/internal/domain/repository"
 )
 
 type txKey struct{}
@@ -28,7 +28,7 @@ type txKey struct{}
 type gormTransactor struct{ db *gorm.DB }
 
 // NewTransactor は Transactor を生成する。
-func NewTransactor(db *gorm.DB) port.Transactor {
+func NewTransactor(db *gorm.DB) repository.Transactor {
 	return &gormTransactor{db: db}
 }
 


### PR DESCRIPTION
### 変更サマリー

- `usecase/port/tx.go` に定義されていた `Transactor` インターフェースを `domain/repository/tx.go` へ移動した。
- 同時に `infra/rdb/tx.go` のインポートを `usecase/port` から `domain/repository` に更新した。
- この変更により `infra` レイヤーの依存先が `domain` のみに一本化され、Clean Architecture の依存ルール（依存は常に内側へ）に完全に準拠する。
- 影響レイヤー: Backend（domain / infra）

### テスト方法

- [x] `go build ./...` でビルド成功を確認済み

### 考慮事項

- 後方互換性: `Transactor` を直接参照しているコードはなく（`wire.go` の `_ = rdb.NewTransactor(db)` のみ）、API スキーマや外部インターフェースへの影響はない。
- その他: 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
