### PR TITLE
fix: EncounterRowの初期化でhideMatchedElementsを復旧

### DIFF
--- a/ios/ios/Features/Encounter/List/EncounterRow.swift
+++ b/ios/ios/Features/Encounter/List/EncounterRow.swift
@@ -3,9 +3,15 @@ import SwiftUI
 struct EncounterRow: View {
     let encounter: Encounter
     let isFixed: Bool
-    let hideMatchedElements: Bool = false
+    let hideMatchedElements: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.encounterNamespace) private var namespace
+
+    init(encounter: Encounter, isFixed: Bool, hideMatchedElements: Bool = false) {
+        self.encounter = encounter
+        self.isFixed = isFixed
+        self.hideMatchedElements = hideMatchedElements
+    }
     
     private var seed: Int {
         let magnitude = encounter.id.hashValue.magnitude


### PR DESCRIPTION
### 変更サマリー

- EncounterRow が hideMatchedElements を受け取れずコンパイルエラーになる問題を修正した。
- デフォルト値を init で持たせ、既存呼び出しに影響しない形で復旧した。
- 影響レイヤー: iOS

### テスト方法

- [ ] 単体テスト（Go: `go test` / Swift: XCTest / Kotlin: JUnit）
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認（Spotify API / Apple Music API / Firebase Auth を含む場合）

補足: 未実施。

### 考慮事項

- 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
