### PR TITLE
docs: ローカルDockerでのiOS BLE実機検証手順を追加

### DIFF
--- a/docs/overview/ble-local-docker-iphone.md
+++ b/docs/overview/ble-local-docker-iphone.md
@@ -32,6 +32,32 @@
 iOS 側は `API_BASE_URL` を参照します。人によって値が変わるため、
 **Scheme の Environment Variables で設定**するのが推奨です。
 
+### Mac のローカル IP を確認する
+
+実機 iPhone からは `localhost` を参照できません。
+必ず **Mac のローカル IP** を使います。
+
+例:
+
+```bash
+ipconfig getifaddr en0
+```
+
+Wi-Fi 利用時はこれで `192.168.x.x` が返ることが多いです。
+
+### 疎通確認
+
+Mac 上で以下を叩き、`404 Not Found` でもよいので
+**バックエンドの JSON レスポンスが返ること**を確認します。
+
+```bash
+curl http://<MAC_LOCAL_IP>:<API_PORT>
+curl http://<MAC_LOCAL_IP>:<API_PORT>/health
+```
+
+ルートや `/health` が 404 でも、
+**`<MAC_LOCAL_IP>:<API_PORT>` に到達できていること自体が確認できれば OK** です。
+
 ### 推奨: Scheme の Environment Variables
 
 - Key: `API_BASE_URL`
@@ -47,6 +73,21 @@ iOS 側は `API_BASE_URL` を参照します。人によって値が変わるた
 アプリは API リクエスト時に **Bearer Token** を要求します。
 そのため、環境変数 `FIREBASE_ID_TOKEN` を設定しておく必要があります。
 
+注意: Firebase Emulator UI に表示される `User UID` をそのまま設定しても認証できません。
+
+- `FIREBASE_ID_TOKEN`
+  - ログイン時に返る **JWT 形式の ID トークン**
+  - 実際に Scheme に設定する値はこちら
+
+`signInWithPassword` のレスポンス例:
+
+```json
+{
+  "localId": "Firebase UID",
+  "idToken": "これをFIREBASE_ID_TOKENに設定する"
+}
+```
+
 ### 推奨: Firebase Auth エミュレータで ID トークンを発行
 
 ローカル運用ではエミュレータの利用が想定されています。
@@ -59,6 +100,62 @@ iOS 側は `API_BASE_URL` を参照します。人によって値が変わるた
 - Key: `FIREBASE_ID_TOKEN`
 - Value: `<ID_TOKEN>`
 
+### 重要: 2 台検証ではユーザーを分ける
+
+BLE 実機 2 台検証では、
+**iPhone A / iPhone B で別ユーザーの ID トークンを使う**ことを推奨します。
+
+例:
+
+- iPhone A
+  - `FIREBASE_ID_TOKEN=<USER_A_ID_TOKEN>`
+- iPhone B
+  - `FIREBASE_ID_TOKEN=<USER_B_ID_TOKEN>`
+
+同じトークンを 2 台で使うより、別ユーザーの方が
+エンカウント登録と画面確認が分かりやすいです。
+
+### 推奨: Scheme を 2 つに分ける
+
+Xcode では以下のように Scheme を分けると運用しやすいです。
+
+- `ios-UserA`
+- `ios-UserB`
+
+どちらも `API_BASE_URL` は同じで、
+`FIREBASE_ID_TOKEN` だけを変えます。
+
+### 重要: ID トークン取得後にアプリ内ユーザーを作成する
+
+Firebase Auth Emulator にユーザーがあるだけでは不十分です。
+バックエンドの `users` テーブルに対応ユーザーが未作成だと、
+以下のような `record not found` が出ます。
+
+```text
+SELECT * FROM "users" WHERE (auth_provider = 'firebase' AND provider_user_id = '...')
+```
+
+その場合は、各 ID トークンごとに一度 `POST /api/v1/users` を実行して
+アプリ内ユーザーを作成してください。
+
+例:
+
+```bash
+curl -X POST http://<MAC_LOCAL_IP>:<API_PORT>/api/v1/users \
+  -H "Authorization: Bearer <ID_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "User A"
+  }'
+```
+
+作成後、以下で確認します。
+
+```bash
+curl http://<MAC_LOCAL_IP>:<API_PORT>/api/v1/users/me \
+  -H "Authorization: Bearer <ID_TOKEN>"
+```
+
 ---
 
 ## 4. iPhone 実機へビルド・インストール（2 台）
@@ -66,7 +163,12 @@ iOS 側は `API_BASE_URL` を参照します。人によって値が変わるた
 1. iPhone A を接続してビルド & インストール
 2. iPhone B を接続してビルド & インストール
 
-※ 同じ Scheme 設定で OK（トークンや API URL は共通でよい）
+推奨:
+
+- iPhone A は `ios-UserA`
+- iPhone B は `ios-UserB`
+
+を使って起動します。
 
 ---
 
@@ -79,6 +181,8 @@ iOS 側は `API_BASE_URL` を参照します。人によって値が変わるた
 **期待される挙動**
 - 端末同士の BLE 検出が発生し、
   `ble-tokens` に紐づくユーザー取得・エンカウント登録が行われる
+- Home 上部の BLE 状態表示が `SCANNING` または `STANDBY` になる
+- 履歴画面に encounter が表示される
 
 ---
 
@@ -91,7 +195,12 @@ iOS 側は `API_BASE_URL` を参照します。人によって値が変わるた
 
 - **401 Unauthorized が返る**
   - `FIREBASE_ID_TOKEN` の設定があるか確認
+  - `User UID` ではなく `idToken` を設定しているか確認
   - 期限切れトークンでないか確認
+
+- **record not found が返る**
+  - Firebase Auth Emulator のユーザーだけ作っていて、
+    アプリ内ユーザーを `POST /api/v1/users` で未作成の可能性が高い
 
 - **BLE 反応が弱い / 出ない**
   - 端末が近いか（数十 cm）

--- a/docs/overview/firebase-auth-emulator-ops.md
+++ b/docs/overview/firebase-auth-emulator-ops.md
@@ -43,6 +43,18 @@ Emulator UI からユーザーを作成します。
 
 作成したユーザーでログインし、ID トークンを取得します。
 
+### 重要: UI に表示される User UID とは別物
+
+Firebase Emulator UI に表示される `User UID` は、
+そのまま `FIREBASE_ID_TOKEN` に設定する値ではありません。
+
+- `localId`
+  - Firebase UID
+- `idToken`
+  - iOS アプリの `FIREBASE_ID_TOKEN` に設定する値
+
+使うのは **`idToken`** です。
+
 ### 方法A: cURL でログインして取得
 
 以下のリクエストで `idToken` を取得できます。
@@ -55,21 +67,108 @@ curl -s "http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signIn
 
 レスポンスの `idToken` を控えます。
 
+レスポンス例:
+
+```json
+{
+  "localId": "tjNMTXMc0bIP9SUcYo9y10oEKJ6t",
+  "email": "a@a",
+  "idToken": "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0...."
+}
+```
+
+- `localId` は UID
+- `idToken` を Scheme に設定する
+
+### 2 ユーザー分発行する
+
+BLE 実機 2 台検証では、最低 2 ユーザー分の `idToken` を取得します。
+
+例:
+
+- User A: `a@a`
+- User B: `b@b`
+
+それぞれ `signInWithPassword` を実行して、
+`USER_A_ID_TOKEN`, `USER_B_ID_TOKEN` を控えます。
+
 ---
 
-## 4. iOS アプリへ ID トークンを設定
+## 4. バックエンドのアプリ内ユーザーを作成する
+
+Firebase Auth Emulator にユーザーが存在しても、
+バックエンドの `users` テーブルに対応レコードが無ければ利用できません。
+
+未作成の場合、以下のようなエラーになります。
+
+```text
+record not found
+SELECT * FROM "users" WHERE (auth_provider = 'firebase' AND provider_user_id = '...')
+```
+
+そのため、各 `idToken` ごとに一度 `POST /api/v1/users` を実行します。
+
+### 例: User A
+
+```bash
+curl -X POST http://<MAC_LOCAL_IP>:8000/api/v1/users \
+  -H "Authorization: Bearer <USER_A_ID_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "User A"
+  }'
+```
+
+### 例: User B
+
+```bash
+curl -X POST http://<MAC_LOCAL_IP>:8000/api/v1/users \
+  -H "Authorization: Bearer <USER_B_ID_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "display_name": "User B"
+  }'
+```
+
+### 作成確認
+
+```bash
+curl http://<MAC_LOCAL_IP>:8000/api/v1/users/me \
+  -H "Authorization: Bearer <USER_A_ID_TOKEN>"
+```
+
+```bash
+curl http://<MAC_LOCAL_IP>:8000/api/v1/users/me \
+  -H "Authorization: Bearer <USER_B_ID_TOKEN>"
+```
+
+JSON でユーザー情報が返れば OK です。
+
+---
+
+## 5. iOS アプリへ ID トークンを設定
 
 Xcode の Scheme で環境変数を設定します。
 
 - Key: `FIREBASE_ID_TOKEN`
 - Value: `<ID_TOKEN>`
 
+BLE 実機 2 台検証では、Scheme を 2 つに分ける運用を推奨します。
+
+例:
+
+- `ios-UserA`
+  - `FIREBASE_ID_TOKEN=<USER_A_ID_TOKEN>`
+- `ios-UserB`
+  - `FIREBASE_ID_TOKEN=<USER_B_ID_TOKEN>`
+
 ---
 
-## 5. 動作確認のポイント
+## 6. 動作確認のポイント
 
 - `FIREBASE_ID_TOKEN` が未設定だと 401 になります
 - トークンには有効期限があるので、401 になったら再発行
+- `record not found` が出る場合は `POST /api/v1/users` が未実行の可能性が高い
 
 ---
 
@@ -83,3 +182,9 @@ Xcode の Scheme で環境変数を設定します。
   - ユーザー作成時のメール/パスワードが合っているか確認
   - `demo-hackathon` をキーに使っているか確認
 
+- **401 Unauthorized**
+  - `idToken` ではなく `localId` / `User UID` を設定していないか確認
+
+- **record not found**
+  - Firebase Emulator 上のユーザー作成だけで終わっていないか確認
+  - バックエンドに対して `POST /api/v1/users` を実行したか確認


### PR DESCRIPTION
## 変更サマリー

- ローカル Docker バックエンドを使って iOS 実機 2 台で BLE を検証する手順書を追加。
- 人によって変わる値はプレースホルダ化し、共通手順を整理。
- 影響レイヤー: docs

## テスト方法

- [ ] 単体テスト
- [ ] API エンドポイントの入出力確認
- [ ] 実機またはシミュレータでの手動確認
- [ ] 外部連携の確認

## 考慮事項

- 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
