### PR TITLE
fix: productionブランチをデプロイ対象に変更

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -3,7 +3,7 @@ name: terraform-apply
 on:
   push:
     branches:
-      - main
+      - production
     paths:
       - "infra/main/**"
       - ".github/workflows/tf-apply.yml"


### PR DESCRIPTION
prod環境を新しく作成するのにあたり、cdの対象branchをproductionに変更
それ以外のci/cdに関しては従来通り動くことが期待される動作。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
