### PR TITLE
docs: developをデフォルトブランチ、mainをprod自動デプロイブランチに更新

### DIFF
--- a/docs/architecture/cicd.md
+++ b/docs/architecture/cicd.md
@@ -3,13 +3,13 @@
 ## 全体フロー
 
 ```
-PR 作成
+PR 作成（feature/* → develop）
   ↓
 [CI] lint / test / schema チェック / terraform plan
-  ↓ approve & merge to main
+  ↓ approve & merge to develop
 [CD] ビルド → dev 自動デプロイ → スキーマ生成・配布
-  ↓ 手動承認
-[CD] prod デプロイ
+  ↓ develop → main へ PR & merge
+[CD] prod 自動デプロイ
 ```
 
 ## PR 時（CI）
@@ -23,7 +23,7 @@ PR 作成
 | `codegen-check` | コード生成を実行し、リポジトリ内の生成コードと差分がないか確認 |
 | `terraform-plan` | `environments/dev` の `terraform plan` を実行し結果を PR コメントに投稿 |
 
-## main マージ時（CD）
+## develop マージ時（CD）
 
 ### 1. ビルド・dev デプロイ
 
@@ -46,15 +46,14 @@ swift-openapi-generator → iOS リポジトリに PR を自動作成
 openapi-generator       → Android リポジトリに PR を自動作成
 ```
 
-### 3. prod デプロイ（手動承認）
+## main マージ時（CD）
 
-GitHub Actions の `environment: production` を使い、
-指定したレビュアーの承認後に実行される。
+`develop` → `main` への PR がマージされると自動的に prod デプロイが実行される。
 
 ```
-手動承認
-    ↓
 terraform apply（environments/prod）
+    ↓
+docker build → Artifact Registry プッシュ
     ↓
 Cloud Run（prod）デプロイ
 ```
@@ -79,9 +78,9 @@ Terraform でプロバイダ・サービスアカウント・IAM バインディ
 
 | ブランチ | 役割 |
 |---|---|
-| `main` | dev 環境への自動デプロイトリガー |
-| `release/*` | prod デプロイ候補（手動承認後に prod 反映） |
-| `feature/*` | 機能開発。PR で main にマージ |
+| `develop` | デフォルトブランチ。dev 環境への自動デプロイトリガー |
+| `main` | prod 環境への自動デプロイトリガー。`develop` からのマージのみ受け付ける |
+| `feature/*` | 機能開発。PR で `develop` にマージ |
 
 ## シークレット管理
 

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -44,8 +44,9 @@ infra/
 
 ### 環境方針
 
-現時点では dev 単一環境（GCP プロジェクト: `musicswapping`）で運用する。
-prod 環境は必要になった時点で `infra/` 配下に別ディレクトリを追加する方針。
+dev / prod の2環境構成で運用する。
+- **dev**: `develop` ブランチへのマージで自動デプロイ（GCP プロジェクト: `musicswapping`）
+- **prod**: `main` ブランチへのマージで自動デプロイ
 
 ### State 管理
 
@@ -99,16 +100,24 @@ terraform fmt / validate / plan
   ↓
 plan 結果を PR コメントに自動投稿
 
-main マージ時
+develop マージ時
   ↓
-terraform apply（自動）
+terraform apply（dev 環境）自動実行
   ↓
 docker build → Artifact Registry プッシュ
   ↓
-Cloud Run 自動デプロイ
+Cloud Run（dev）自動デプロイ
+
+main マージ時（develop → main）
+  ↓
+terraform apply（prod 環境）自動実行
+  ↓
+docker build → Artifact Registry プッシュ
+  ↓
+Cloud Run（prod）自動デプロイ
 ```
 
-- `infra/main/**` の変更は main マージで自動 apply
+- `infra/main/**` の変更は develop マージで dev 環境に自動 apply、main マージで prod 環境に自動 apply
 
 ## 開発環境（Docker）
 


### PR DESCRIPTION
## 変更サマリー

- デフォルトブランチを `main` から `develop` に変更したことに伴い、CI/CD およびインフラドキュメントを更新した。
- `develop` マージで dev 自動デプロイ、`main`（`develop` → `main` PR マージ）で prod 自動デプロイという2段階フローに変更。
- 従来の `release/*` ブランチ + 手動承認フローを廃止し、`main` マージトリガーの自動デプロイに統一した。
- 影響レイヤー: ドキュメント（`docs/architecture/cicd.md`, `docs/architecture/infrastructure.md`）

## テスト方法

- [ ] ドキュメントの記述が実際のブランチ戦略・ワークフロー設定と一致していること目視確認

## 考慮事項

該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
