### PR TITLE
test: add encounter model classification tests

### DIFF
--- a/ios/iosTests/EncounterModelTests.swift
+++ b/ios/iosTests/EncounterModelTests.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import XCTest
+
+@testable import ios
+
+final class EncounterModelTests: XCTestCase {
+    private func makeEncounter(relativeTime: String) -> Encounter {
+        Encounter(
+            id: "enc-1",
+            userName: "mio",
+            track: Track(title: "Song", artist: "Artist", color: .blue),
+            relativeTime: relativeTime,
+            lyric: ""
+        )
+    }
+
+    func testEncounterHappenedTodayMatchesRelativeTimeLabels() {
+        let samples = ["たった今", "3分前", "2時間前", "近日"]
+
+        for label in samples {
+            let encounter = makeEncounter(relativeTime: label)
+            XCTAssertTrue(encounter.happenedToday, "Expected \(label) to be treated as today")
+            XCTAssertFalse(encounter.happenedYesterday)
+            XCTAssertFalse(encounter.happenedEarlier)
+        }
+    }
+
+    func testEncounterHappenedYesterdayMatchesLabel() {
+        let encounter = makeEncounter(relativeTime: "昨日")
+
+        XCTAssertTrue(encounter.happenedYesterday)
+        XCTAssertFalse(encounter.happenedToday)
+        XCTAssertFalse(encounter.happenedEarlier)
+    }
+
+    func testEncounterHappenedEarlierForPastDays() {
+        let encounter = makeEncounter(relativeTime: "2日前")
+
+        XCTAssertTrue(encounter.happenedEarlier)
+        XCTAssertFalse(encounter.happenedToday)
+        XCTAssertFalse(encounter.happenedYesterday)
+    }
+
+    func testEncounterSectionsIncludeExpectedEncounters() {
+        let today = makeEncounter(relativeTime: "5分前")
+        let yesterday = makeEncounter(relativeTime: "昨日")
+        let earlier = makeEncounter(relativeTime: "3日前")
+
+        XCTAssertTrue(EncounterSection.today.includes(today))
+        XCTAssertTrue(EncounterSection.yesterday.includes(yesterday))
+        XCTAssertTrue(EncounterSection.earlier.includes(earlier))
+
+        XCTAssertFalse(EncounterSection.today.includes(earlier))
+        XCTAssertFalse(EncounterSection.yesterday.includes(today))
+    }
+}


### PR DESCRIPTION
### 変更サマリー

- Encounter の相対時間ラベルに基づく分類ロジックを最小限の単体テストでカバーした。
- 今日/昨日/以前のセクション分けが期待通りに判定されることを確認できるようにした。
- 影響レイヤー: iOS / テスト

### ロジック変更の図解

なし（ロジック変更なし）

### テスト方法

- [ ] 単体テスト（Go: `go test` / Swift: XCTest / Kotlin: JUnit）
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認（Spotify API / Apple Music API / Firebase Auth を含む場合）

### 考慮事項

- 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
