### PR TITLE
fix: seedのencounter_tracks重複判定に条件を追加

### DIFF
--- a/backend/internal/infra/rdb/seed.go
+++ b/backend/internal/infra/rdb/seed.go
@@ -177,6 +177,11 @@ func seedDemoData(db *gorm.DB) error {
 				{Name: "track_id"},
 				{Name: "source_user_id"},
 			},
+			TargetWhere: clause.Where{
+				Exprs: []clause.Expression{
+					clause.Expr{SQL: "deleted_at IS NULL"},
+				},
+			},
 			DoNothing: true,
 		}).Create(&model.EncounterTrack{
 			ID:           encounterTrackID,


### PR DESCRIPTION
### 変更サマリー
- seed の encounter_tracks 追加時に、部分ユニークインデックス（deleted_at IS NULL）と一致する ON CONFLICT 条件を付与した。
- これにより init-db の seed 実行時に発生する衝突エラーを回避できる。
- 影響レイヤー: Backend / DB seed

### ロジック変更の図解
- 該当なし

### テスト方法
- [ ] 単体テスト（Go: `go test`）
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認（Spotify API / Apple Music API / Firebase Auth を含む場合）

### 考慮事項
- プライバシー: 該当なし
- セキュリティ: 該当なし
- 後方互換性: 該当なし
- パフォーマンス: 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
