### PR TITLE
fix: Terraform CI SA に cloudrun-sa / worker-sa への actAs 権限を追加

### DIFF
--- a/infra/main/iam.tf
+++ b/infra/main/iam.tf
@@ -126,6 +126,21 @@ resource "google_service_account_iam_member" "terraform_ci_wif" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
 }
 
+# Terraform CI SA → cloudrun-sa / worker-sa の actAs 権限
+# Cloud Run Service/Job 作成時に service_account を指定するには
+# デプロイ主体が対象 SA に対して iam.serviceaccounts.actAs を持つ必要がある
+resource "google_service_account_iam_member" "terraform_ci_actas_cloudrun" {
+  service_account_id = google_service_account.cloudrun.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.terraform_ci.email}"
+}
+
+resource "google_service_account_iam_member" "terraform_ci_actas_worker" {
+  service_account_id = google_service_account.worker.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.terraform_ci.email}"
+}
+
 # GitHub Actions Secrets に登録する値の出力
 output "wif_provider" {
   value       = google_iam_workload_identity_pool_provider.github.name


### PR DESCRIPTION
## 変更サマリー

PR #97 の apply で発生した `iam.serviceaccounts.actAs` 403 エラーの修正。

Cloud Run Service/Job に `service_account` を指定して作成する場合、デプロイ主体（`terraform-ci-sa`）が対象 SA に対して `iam.serviceaccounts.actAs` 権限を持つ必要がある。`roles/iam.serviceAccountAdmin`（既存）はこの権限を含まないため、`roles/iam.serviceAccountUser` を SA レベルで個別に付与する。

- `google_service_account_iam_member.terraform_ci_actas_cloudrun`: `cloudrun-sa` への `roles/iam.serviceAccountUser`
- `google_service_account_iam_member.terraform_ci_actas_worker`: `worker-sa` への `roles/iam.serviceAccountUser`

## テスト方法

- [ ] `terraform plan` で IAM binding 2件の追加を確認
- [ ] apply 後に Cloud Run Service `api` と Job `worker` が正常に作成されること

## 考慮事項

- プロジェクトレベルではなく SA レベルの付与のため最小権限の原則を維持
- PR #97（cloudrun.tf）の apply 完了後にマージすること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
