### PR TITLE
fix: Cloud Run 初回 apply をプレースホルダーイメージで通過させる

### DIFF
--- a/infra/main/cloudrun.tf
+++ b/infra/main/cloudrun.tf
@@ -1,6 +1,10 @@
 locals {
-  image_server = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}/server:latest"
-  image_worker = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}/worker:latest"
+  # 初回 apply 時は実イメージが未 push のためプレースホルダーを使用。
+  # CI/CD（deploy.yml）が実イメージを push・デプロイするため、
+  # lifecycle.ignore_changes = [template] で Terraform による上書きを防ぐ。
+  image_placeholder = "us-docker.pkg.dev/cloudrun/container/hello:latest"
+  image_server      = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}/server:latest"
+  image_worker      = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.app.repository_id}/worker:latest"
 }
 
 # Cloud Run Service（API サーバー）
@@ -26,7 +30,7 @@ resource "google_cloud_run_v2_service" "api" {
     }
 
     containers {
-      image = local.image_server
+      image = local.image_placeholder
 
       env {
         name  = "DB_USER"
@@ -130,6 +134,10 @@ resource "google_cloud_run_v2_service" "api" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [template]
+  }
+
   depends_on = [
     google_project_service.apis,
     google_secret_manager_secret_version.db_password,
@@ -164,7 +172,7 @@ resource "google_cloud_run_v2_job" "worker" {
       }
 
       containers {
-        image = local.image_worker
+        image = local.image_placeholder
 
         resources {
           limits = {
@@ -204,6 +212,10 @@ resource "google_cloud_run_v2_job" "worker" {
         }
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [template]
   }
 
   depends_on = [


### PR DESCRIPTION
## 変更サマリー

実イメージが Artifact Registry に未 push の状態での apply エラーを修正。

- `cloudrun.tf`: Service / Job のイメージを `us-docker.pkg.dev/cloudrun/container/hello:latest`（Google 公式プレースホルダー）に変更
- `lifecycle { ignore_changes = [template] }` を追加し、CI/CD によるイメージ更新を Terraform が上書きしないよう設定

## 動作フロー

```
terraform apply（初回）
  → プレースホルダーイメージで Service / Job を作成
      → CI/CD（deploy.yml）が実イメージを push・gcloud run deploy で更新
          → Terraform は template を ignore するため以降の apply で上書きされない
```

## テスト方法

- [ ] `terraform plan` で Service / Job が `1 to add` になること（既存リソースは削除済みのため）
- [ ] apply 後に Cloud Run Service `api` がプレースホルダーイメージで起動すること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
