### PR TITLE
fix: ログ時刻をJSTに統一

### DIFF
--- a/backend/cmd/init-db/main.go
+++ b/backend/cmd/init-db/main.go
@@ -21,6 +21,12 @@ const (
 )
 
 func main() {
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		panic("time location load failed: " + err.Error())
+	}
+	time.Local = loc
+
 	cfg, err := config.Load()
 	if err != nil {
 		panic("config load failed: " + err.Error())

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -29,6 +29,12 @@ import (
 )
 
 func main() {
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		panic("time location load failed: " + err.Error())
+	}
+	time.Local = loc
+
 	cfg, err := config.Load()
 	if err != nil {
 		panic("config load failed: " + err.Error())
@@ -74,6 +80,7 @@ func main() {
 	e.HideBanner = true
 	e.Use(middleware.Recover())
 	e.Use(middleware.RequestID())
+	e.Use(middleware.Logger())
 
 	// Swagger UI は development / test 環境のみ公開する（Seed と同じ allowlist 方式）
 	if cfg.GoEnv == "development" || cfg.GoEnv == "test" {

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -7,6 +7,12 @@ import (
 )
 
 func main() {
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		panic("time location load failed: " + err.Error())
+	}
+	time.Local = loc
+
 	interval := 30 * time.Second
 	if os.Getenv("WORKER_ONESHOT") == "true" {
 		log.Println("worker oneshot: boot ok")


### PR DESCRIPTION
### 変更サマリー
- サーバー起動直後に `time.Local` を Asia/Tokyo に設定し、アプリ全体の時刻出力をJSTに統一した。
- `init-db` と `worker` でも同様にタイムゾーンを設定して、GORM/標準ログの時刻ズレを防いだ。
- 影響レイヤー: Backend

### ロジック変更の図解
なし

### テスト方法
- [ ] 単体テスト（Go: `go test` / Swift: XCTest / Kotlin: JUnit）
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認（Spotify API / Apple Music API / Firebase Auth を含む場合）

### 考慮事項
- プライバシー: 該当なし
- セキュリティ: 該当なし
- 後方互換性: ログ時刻の表示タイムゾーンがJSTに統一される
- パフォーマンス: 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
