### PR TITLE
fix: Terraform CI SA に scheduler-sa への actAs 権限を追加

### DIFF
--- a/infra/main/iam.tf
+++ b/infra/main/iam.tf
@@ -141,6 +141,12 @@ resource "google_service_account_iam_member" "terraform_ci_actas_worker" {
   member             = "serviceAccount:${google_service_account.terraform_ci.email}"
 }
 
+resource "google_service_account_iam_member" "terraform_ci_actas_scheduler" {
+  service_account_id = google_service_account.scheduler.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.terraform_ci.email}"
+}
+
 # GitHub Actions Secrets に登録する値の出力
 output "wif_provider" {
   value       = google_iam_workload_identity_pool_provider.github.name


### PR DESCRIPTION
## 変更サマリー

Cloud Scheduler ジョブ作成時の 403 エラーを修正。

`google_cloud_scheduler_job` の `oauth_token.service_account_email` に `scheduler-sa` を指定する場合、デプロイ主体（`terraform-ci-sa`）が `scheduler-sa` に対して `iam.serviceaccounts.actAs` を持つ必要がある。`cloudrun-sa` / `worker-sa` と同様に `roles/iam.serviceAccountUser` を SA レベルで付与。

## テスト方法

- [ ] `terraform plan` で IAM binding 1件の追加を確認
- [ ] apply 後に Cloud Scheduler ジョブ `worker-kick` が正常に作成されること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
