### PR TITLE
test: DB接続とマイグレーションをパッケージ全体で1回だけ実行してテストを高速化

### DIFF
--- a/backend/internal/handler/main_test.go
+++ b/backend/internal/handler/main_test.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"hackathon/internal/infra/rdb"
+)
+
+// sharedTestDB はパッケージ内の全テストが共有する DB 接続。
+// TestMain でマイグレーション済みの状態になる。PostgreSQL が利用不可の場合は nil。
+var sharedTestDB *gorm.DB
+
+// TestMain はパッケージ全体で一度だけ DB 接続とマイグレーションを実行する。
+// テスト関数ごとに rdb.Migrate を呼ぶ代わりにここで 1 回だけ実行することで
+// スキーマ照会のオーバーヘッドを削減する。
+func TestMain(m *testing.M) {
+	dsn := os.Getenv("PG_TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://postgres:postgres@127.0.0.1:5432/hackathon?sslmode=disable"
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		log.Printf("postgres not reachable, skipping DB-backed tests: %v", err)
+		os.Exit(m.Run())
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Fatalf("get sql.DB: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := sqlDB.PingContext(ctx); err != nil {
+		log.Printf("postgres ping failed, skipping DB-backed tests: %v", err)
+		os.Exit(m.Run())
+	}
+
+	if err := rdb.Migrate(db); err != nil {
+		log.Fatalf("migrate: %v", err)
+	}
+
+	sharedTestDB = db
+	os.Exit(m.Run())
+}

--- a/backend/internal/handler/router_postgres_integration_test.go
+++ b/backend/internal/handler/router_postgres_integration_test.go
@@ -3,17 +3,14 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"hackathon/internal/infra/rdb"
@@ -24,32 +21,11 @@ import (
 func openPostgresIntegrationDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
-	dsn := os.Getenv("PG_TEST_DATABASE_URL")
-	if dsn == "" {
-		dsn = "postgres://postgres:postgres@127.0.0.1:5432/hackathon?sslmode=disable"
+	if sharedTestDB == nil {
+		t.Skip("skip integration test: postgres not available")
 	}
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		t.Skipf("skip integration test: postgres is not reachable (%v)", err)
-	}
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		t.Fatalf("get sql.DB: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := sqlDB.PingContext(ctx); err != nil {
-		t.Skipf("skip integration test: postgres ping failed (%v)", err)
-	}
-
-	if err := rdb.Migrate(db); err != nil {
-		t.Fatalf("migrate postgres: %v", err)
-	}
-
-	return db
+	return sharedTestDB
 }
 
 func cleanupPostgresTestData(t *testing.T, db *gorm.DB) {

--- a/backend/internal/handler/router_test.go
+++ b/backend/internal/handler/router_test.go
@@ -6,14 +6,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
 	firebaseauth "firebase.google.com/go/v4/auth"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"hackathon/internal/infra/crypto"
@@ -50,37 +48,16 @@ func (testAuthUserManager) DeleteUser(_ context.Context, _ string) error { retur
 func newTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 
-	dsn := os.Getenv("PG_TEST_DATABASE_URL")
-	if dsn == "" {
-		dsn = "postgres://postgres:postgres@127.0.0.1:5432/hackathon?sslmode=disable"
+	if sharedTestDB == nil {
+		t.Skip("skip postgres-backed router test: postgres not available")
 	}
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
-	if err != nil {
-		t.Skipf("skip postgres-backed router test: postgres is not reachable (%v)", err)
-	}
-
-	sqlDB, err := db.DB()
-	if err != nil {
-		t.Fatalf("get sql.DB: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := sqlDB.PingContext(ctx); err != nil {
-		t.Skipf("skip postgres-backed router test: postgres ping failed (%v)", err)
-	}
-
-	if err := rdb.Migrate(db); err != nil {
-		t.Fatalf("migrate postgres: %v", err)
-	}
-
-	cleanupPostgresTestDataForRouter(t, db)
+	cleanupPostgresTestDataForRouter(t, sharedTestDB)
 	t.Cleanup(func() {
-		cleanupPostgresTestDataForRouter(t, db)
+		cleanupPostgresTestDataForRouter(t, sharedTestDB)
 	})
 
-	return db
+	return sharedTestDB
 }
 
 func cleanupPostgresTestDataForRouter(t *testing.T, db *gorm.DB) {


### PR DESCRIPTION
### 変更サマリー

`handler` パッケージのテストが1件あたり約15秒かかっていた問題を修正した。

原因は各テスト関数が `newTestDB` 経由で `rdb.Migrate` を呼び出しており、毎回スキーマ照会クエリが大量に発行されていたこと。`TestMain` を追加してパッケージ全体で1度だけ DB 接続・マイグレーションを実行し、結果を `sharedTestDB` で共有する形に変更した。

- 影響レイヤー: Backend テスト基盤

### テスト方法

- [ ] 単体テスト（`go test ./internal/handler/... -timeout 300s`）— 全件 PASS することを確認

### 考慮事項

- **後方互換性**: テストロジック自体は変更なし。`sharedTestDB` が nil の場合（postgres 未起動時）は従来通り `t.Skip` でスキップする。
- **並列実行**: 各テストは `cleanupPostgresTestDataForRouter` で TRUNCATE するため、並列実行は行わない（既存の設計を維持）。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
