### PR TITLE
feat: iOS向けシードデータを拡充

### DIFF
--- a/backend/internal/infra/rdb/seed.go
+++ b/backend/internal/infra/rdb/seed.go
@@ -199,10 +199,7 @@ func seedDemoData(db *gorm.DB) error {
 			{ID: settingsIDB, UserID: userB.ID},
 			{ID: settingsIDC, UserID: userC.ID},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "user_id"}},
-			DoNothing: true,
-		}).Create(&settings).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&settings).Error; err != nil {
 			return err
 		}
 
@@ -229,10 +226,7 @@ func seedDemoData(db *gorm.DB) error {
 				ArtistName: "Loop Sisters",
 			},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "external_id"}, {Name: "provider"}},
-			DoNothing: true,
-		}).Create(&tracks).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&tracks).Error; err != nil {
 			return err
 		}
 
@@ -247,19 +241,7 @@ func seedDemoData(db *gorm.DB) error {
 			return err
 		}
 
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "encounter_id"},
-				{Name: "track_id"},
-				{Name: "source_user_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&model.EncounterTrack{
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&model.EncounterTrack{
 			ID:           encounterTrackID,
 			EncounterID:  encounterID,
 			TrackID:      trackIDA,
@@ -288,18 +270,7 @@ func seedDemoData(db *gorm.DB) error {
 			{ID: userTrackIDB, UserID: userA.ID, TrackID: trackIDB},
 			{ID: userTrackIDC, UserID: userB.ID, TrackID: trackIDC},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "user_id"},
-				{Name: "track_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&userTracks).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&userTracks).Error; err != nil {
 			return err
 		}
 
@@ -307,10 +278,7 @@ func seedDemoData(db *gorm.DB) error {
 			{ID: currentTrackIDA, UserID: userA.ID, TrackID: trackIDB},
 			{ID: currentTrackIDB, UserID: userB.ID, TrackID: trackIDC},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "user_id"}},
-			DoNothing: true,
-		}).Create(&currentTracks).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&currentTracks).Error; err != nil {
 			return err
 		}
 
@@ -329,54 +297,21 @@ func seedDemoData(db *gorm.DB) error {
 			{ID: playlistTrackIDB, PlaylistID: playlistIDA, TrackID: trackIDB, SortOrder: 2},
 			{ID: playlistTrackIDC, PlaylistID: playlistIDB, TrackID: trackIDC, SortOrder: 1},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "playlist_id"},
-				{Name: "track_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&playlistTracks).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&playlistTracks).Error; err != nil {
 			return err
 		}
 
 		trackFavorites := []model.TrackFavorite{
 			{ID: trackFavoriteIDA, UserID: userA.ID, TrackID: trackIDC},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "user_id"},
-				{Name: "track_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&trackFavorites).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&trackFavorites).Error; err != nil {
 			return err
 		}
 
 		playlistFavorites := []model.PlaylistFavorite{
 			{ID: playlistFavIDA, UserID: userA.ID, PlaylistID: playlistIDB},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "user_id"},
-				{Name: "playlist_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&playlistFavorites).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&playlistFavorites).Error; err != nil {
 			return err
 		}
 
@@ -399,10 +334,7 @@ func seedDemoData(db *gorm.DB) error {
 		// Keep demo data resilient to resets by ensuring a BLE token exists for the demo user.
 		validFrom := time.Now().UTC().Add(-10 * time.Minute)
 		validTo := time.Now().UTC().Add(24 * time.Hour)
-		if err := tx.Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "token"}},
-			DoNothing: true,
-		}).Create(&model.BleToken{
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&model.BleToken{
 			ID:        "seed-ble-token-01",
 			UserID:    userB.ID,
 			Token:     "0123456789abcdef",
@@ -423,14 +355,7 @@ func seedDemoData(db *gorm.DB) error {
 				Enabled:     true,
 			},
 		}
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "user_id"},
-				{Name: "platform"},
-				{Name: "device_id"},
-			},
-			DoNothing: true,
-		}).Create(&devices).Error; err != nil {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&devices).Error; err != nil {
 			return err
 		}
 
@@ -438,18 +363,7 @@ func seedDemoData(db *gorm.DB) error {
 			return err
 		}
 
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "blocker_user_id"},
-				{Name: "blocked_user_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&model.Block{
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&model.Block{
 			ID:            blockIDA,
 			BlockerUserID: userA.ID,
 			BlockedUserID: userC.ID,
@@ -457,18 +371,7 @@ func seedDemoData(db *gorm.DB) error {
 			return err
 		}
 
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "user_id"},
-				{Name: "target_user_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&model.Mute{
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&model.Mute{
 			ID:           muteIDA,
 			UserID:       userB.ID,
 			TargetUserID: userC.ID,
@@ -476,20 +379,7 @@ func seedDemoData(db *gorm.DB) error {
 			return err
 		}
 
-		if err := tx.Clauses(clause.OnConflict{
-			Columns: []clause.Column{
-				{Name: "reporter_user_id"},
-				{Name: "reported_user_id"},
-				{Name: "report_type"},
-				{Name: "target_comment_id"},
-			},
-			TargetWhere: clause.Where{
-				Exprs: []clause.Expression{
-					clause.Expr{SQL: "deleted_at IS NULL"},
-				},
-			},
-			DoNothing: true,
-		}).Create(&[]model.Report{
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&[]model.Report{
 			{
 				ID:             reportUserIDA,
 				ReporterUserID: userA.ID,
@@ -537,10 +427,7 @@ func seedMusicConnections(tx *gorm.DB, id, userID string) error {
 	expiresAt := time.Now().UTC().Add(48 * time.Hour)
 	username := "demo_spotify_user"
 
-	return tx.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "user_id"}, {Name: "provider"}},
-		DoNothing: true,
-	}).Create(&model.MusicConnection{
+	return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&model.MusicConnection{
 		ID:               id,
 		UserID:           userID,
 		Provider:         "spotify",
@@ -611,25 +498,11 @@ func seedLyricData(tx *gorm.DB, userAID, userBID, userCID, encounterAID, encount
 			GeneratedAt: ptrTime(now.Add(-70 * time.Minute)),
 		},
 	}
-	if err := tx.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "chain_id"}},
-		DoNothing: true,
-	}).Create(&songs).Error; err != nil {
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&songs).Error; err != nil {
 		return err
 	}
 
-	if err := tx.Clauses(clause.OnConflict{
-		Columns: []clause.Column{
-			{Name: "song_id"},
-			{Name: "user_id"},
-		},
-		TargetWhere: clause.Where{
-			Exprs: []clause.Expression{
-				clause.Expr{SQL: "deleted_at IS NULL"},
-			},
-		},
-		DoNothing: true,
-	}).Create(&model.SongLike{
+	if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&model.SongLike{
 		ID:     songLikeIDA,
 		SongID: generatedSongIDA,
 		UserID: userAID,


### PR DESCRIPTION
### 変更サマリー
- iOS 向けの動作確認で不足しがちなデータを補うため、デモシードにデバイス/音楽連携/ブロック・ミュート/歌詞チェーン・生成曲/いいねを追加した。
- 通知に既読データを加え、通知一覧/既読/削除の一連が確認しやすい状態にした。
- 音楽連携のシードで暗号化トークンを生成するようにし、連携一覧/削除が動作する前提を整えた。
- 影響レイヤー: Backend / DB seed

### ロジック変更の図解
該当なし

### テスト方法
- [ ] 単体テスト（Go: `go test` / Swift: XCTest / Kotlin: JUnit）
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認（Spotify API / Apple Music API / Firebase Auth を含む場合）

補足: `make fmt` を実行。

### 考慮事項
- プライバシー: 該当なし（デモデータのみ）
- セキュリティ: 音楽連携シードは `MUSIC_TOKEN_ENCRYPTION_KEY` が必要
- 後方互換性: 既存の seed は維持
- パフォーマンス: 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
