### PR TITLE
feat: 通知オフ時にプッシュトークンを削除

### DIFF
--- a/ios/ios/Core/Services/Notifications/PushNotificationManager.swift
+++ b/ios/ios/Core/Services/Notifications/PushNotificationManager.swift
@@ -109,17 +109,38 @@ final class PushNotificationManager: NSObject, ObservableObject {
             return
         }
 
-        do {
-            _ = try await apiClient.patchPushToken(
-                id: backendId,
-                request: UpdatePushTokenRequest(
-                    pushToken: nil,
-                    enabled: enabled,
-                    appVersion: Self.appVersion
+        if enabled {
+            do {
+                _ = try await apiClient.patchPushToken(
+                    id: backendId,
+                    request: UpdatePushTokenRequest(
+                        pushToken: nil,
+                        enabled: true,
+                        appVersion: Self.appVersion
+                    )
                 )
-            )
+            } catch {
+                lastErrorMessage = "通知設定の同期に失敗しました。"
+            }
+            return
+        }
+
+        do {
+            try await apiClient.deletePushToken(id: backendId)
+            store.backendDeviceId = nil
         } catch {
-            lastErrorMessage = "通知設定の同期に失敗しました。"
+            do {
+                _ = try await apiClient.patchPushToken(
+                    id: backendId,
+                    request: UpdatePushTokenRequest(
+                        pushToken: nil,
+                        enabled: false,
+                        appVersion: Self.appVersion
+                    )
+                )
+            } catch {
+                lastErrorMessage = "通知設定の同期に失敗しました。"
+            }
         }
     }
 


### PR DESCRIPTION
### 変更サマリー
- 通知オフ時に push token を削除する処理を追加し、バックエンドの DELETE エンドポイントを利用するようにした。
- 削除に失敗した場合は PATCH で無効化するフォールバックを行い、通知状態の同期失敗を減らす。
- 影響レイヤー: iOS

### ロジック変更の図解
- なし

### テスト方法
- [ ] 単体テスト（Go: `go test` / Swift: XCTest / Kotlin: JUnit）
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認（Spotify API / Apple Music API / Firebase Auth を含む場合）

### 考慮事項
- 該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
