### PR TITLE
fix: worker Job に WORKER_ONESHOT=true を追加し無限ループを解消

### DIFF
--- a/infra/main/cloudrun.tf
+++ b/infra/main/cloudrun.tf
@@ -185,6 +185,11 @@ resource "google_cloud_run_v2_job" "worker" {
         }
 
         env {
+          name  = "WORKER_ONESHOT"
+          value = "true"
+        }
+
+        env {
           name  = "DB_USER"
           value = google_sql_user.app.name
         }


### PR DESCRIPTION
## 変更サマリー

- worker Job が `WORKER_ONESHOT=true` 未設定のため heartbeat ループに入り、10秒タイムアウトで強制終了・`EXECUTION_FAILED` になっていた。
- cloudrun.tf の worker Job に `WORKER_ONESHOT=true` 環境変数を追加して即時終了するよう修正。
- 影響レイヤー: インフラ (Terraform) / Cloud Run Job

## テスト方法

- [ ] main マージ後に `tf-apply.yml` が正常完了することを確認
- [ ] Cloud Scheduler による次回実行（10分ごと）で `EXECUTION_FAILED` が出なくなることを確認

## 考慮事項

該当なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
