### PR TITLE
fix: tf-apply のイメージタグ取得で空文字列フォールバックを修正

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -38,19 +38,20 @@ jobs:
 
       - name: Get current image tags
         run: |
-          # gcloud が失敗しても awk が exit 0 を返すため || フォールバックは機能しない。
+          # GitHub Actions は pipefail が有効なため、gcloud 失敗時にパイプライン全体が
+          # 非ゼロを返してステップが終了する。|| true で失敗を吸収してから
           # ${VAR:-latest} で空文字列も含めて latest にフォールバックする。
           SERVER_TAG=$(gcloud run services describe api \
             --region asia-northeast1 \
             --project ${{ vars.TF_PROJECT_ID }} \
             --format='value(spec.template.spec.containers[0].image)' 2>/dev/null \
-            | awk -F: '{print $NF}')
+            | awk -F: '{print $NF}' || true)
           SERVER_TAG=${SERVER_TAG:-latest}
           WORKER_TAG=$(gcloud run services describe worker \
             --region asia-northeast1 \
             --project ${{ vars.TF_PROJECT_ID }} \
             --format='value(spec.template.spec.containers[0].image)' 2>/dev/null \
-            | awk -F: '{print $NF}')
+            | awk -F: '{print $NF}' || true)
           WORKER_TAG=${WORKER_TAG:-latest}
           echo "TF_VAR_server_image_tag=$SERVER_TAG" >> $GITHUB_ENV
           echo "TF_VAR_worker_image_tag=$WORKER_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
## 原因

`gcloud run services describe ... | awk -F: '{print $NF}' || echo "latest"` の構造で、
gcloud がリソース未存在などで失敗しても **pipe 先の `awk` が空入力で exit 0 を返す**ため、
`|| echo "latest"` フォールバックが発火しない。

結果として `TF_VAR_worker_image_tag=""` となり、
`image = "asia-northeast1-docker.pkg.dev/.../worker:"` という末尾コロン付きの不正な image パスが生成されて terraform apply が 400 エラーで失敗する。

## 修正内容

`|| echo "latest"` パターンを `${VAR:-latest}` に変更。
空文字列・未設定の両方を `latest` にフォールバックするよう修正。

```diff
- SERVER_TAG=$(... | awk -F: '{print $NF}' || echo "latest")
+ SERVER_TAG=$(... | awk -F: '{print $NF}')
+ SERVER_TAG=${SERVER_TAG:-latest}
```

`SERVER_TAG` / `WORKER_TAG` の両方に適用。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
