### PR TITLE
fix: tf-apply で MIGRATE_TAG が未定義のまま参照される問題を修正

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -53,6 +53,12 @@ jobs:
             --format='value(spec.template.spec.containers[0].image)' 2>/dev/null \
             | awk -F: '{print $NF}' || true)
           WORKER_TAG=${WORKER_TAG:-latest}
+          MIGRATE_TAG=$(gcloud run jobs describe migrate \
+            --region asia-northeast1 \
+            --project ${{ vars.TF_PROJECT_ID }} \
+            --format='value(spec.template.spec.containers[0].image)' 2>/dev/null \
+            | awk -F: '{print $NF}' || true)
+          MIGRATE_TAG=${MIGRATE_TAG:-latest}
           echo "TF_VAR_server_image_tag=$SERVER_TAG" >> $GITHUB_ENV
           echo "TF_VAR_worker_image_tag=$WORKER_TAG" >> $GITHUB_ENV
           echo "TF_VAR_migrate_image_tag=$MIGRATE_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- `tf-apply.yml` の `Get current image tags` ステップで `$MIGRATE_TAG` が未定義のまま参照されており、空文字列が `TF_VAR_migrate_image_tag` に渡っていた
- 結果として Terraform がイメージパス `migrate:` を不正な形式として拒否し `Error 400` で失敗していた
- `SERVER_TAG` / `WORKER_TAG` と同一パターンで `gcloud run jobs describe migrate` からタグを取得し、Job 未存在時は `:-latest` でフォールバックするブロックを追加

## Test plan

- [ ] `tf-apply` ワークフローが `Error creating Job: ... must be a container image path` エラーなく通過すること
- [ ] migrate Job が初回作成（Job 未存在）の場合は `latest` タグで作成されること
- [ ] migrate Job が既存の場合は現在のイメージタグが引き継がれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
