### PR TITLE
feat: migrate を Cloud Run Job から Cloud Run Service（Function）に変換

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -43,16 +43,20 @@ jobs:
           docker push $IMAGE:${{ github.sha }}
           docker push $IMAGE:latest
 
-      - name: Update migrate Job image
+      - name: Deploy migrate Service
         run: |
-          gcloud run jobs update migrate \
+          gcloud run services update migrate \
             --image asia-northeast1-docker.pkg.dev/${{ vars.TF_PROJECT_ID }}/app/migrate:${{ github.sha }} \
             --region asia-northeast1 \
             --project ${{ vars.TF_PROJECT_ID }}
 
       - name: Run DB migration
         run: |
-          gcloud run jobs execute migrate \
+          MIGRATE_URL=$(gcloud run services describe migrate \
             --region asia-northeast1 \
             --project ${{ vars.TF_PROJECT_ID }} \
-            --wait
+            --format='value(status.url)')
+          TOKEN=$(gcloud auth print-identity-token --audiences="$MIGRATE_URL")
+          curl -sf -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            "$MIGRATE_URL/"

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -53,7 +53,7 @@ jobs:
             --format='value(spec.template.spec.containers[0].image)' 2>/dev/null \
             | awk -F: '{print $NF}' || true)
           WORKER_TAG=${WORKER_TAG:-latest}
-          MIGRATE_TAG=$(gcloud run jobs describe migrate \
+          MIGRATE_TAG=$(gcloud run services describe migrate \
             --region asia-northeast1 \
             --project ${{ vars.TF_PROJECT_ID }} \
             --format='value(spec.template.spec.containers[0].image)' 2>/dev/null \

--- a/infra/main/cloudrun.tf
+++ b/infra/main/cloudrun.tf
@@ -233,65 +233,69 @@ resource "google_cloud_run_v2_service" "worker" {
   ]
 }
 
-# Cloud Run Job（DB マイグレーション）
-resource "google_cloud_run_v2_job" "migrate" {
+# Cloud Run Service（DB マイグレーション）
+# CI/CD から HTTP POST でトリガーされる。worker と同一パターン。
+resource "google_cloud_run_v2_service" "migrate" {
   name     = "migrate"
   location = var.region
 
   deletion_protection = false
 
   template {
-    template {
-      max_retries     = 0      # マイグレーションは失敗時に即停止（自動リトライ禁止）
-      timeout         = "300s" # 最大 5 分
-      service_account = google_service_account.worker.email
+    service_account = google_service_account.worker.email
 
-      volumes {
-        name = "cloudsql"
-        cloud_sql_instance {
-          instances = [google_sql_database_instance.main.connection_name]
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.main.connection_name]
+      }
+    }
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 1
+    }
+
+    containers {
+      image = local.image_migrate
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+        cpu_idle          = true
+        startup_cpu_boost = false
+      }
+
+      env {
+        name  = "DB_USER"
+        value = google_sql_user.app.name
+      }
+
+      env {
+        name  = "DB_NAME"
+        value = google_sql_database.app.name
+      }
+
+      env {
+        name  = "DB_CONNECTION_NAME"
+        value = google_sql_database_instance.main.connection_name
+      }
+
+      env {
+        name = "DB_PASSWORD"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.db_password.secret_id
+            version = "latest"
+          }
         }
       }
 
-      containers {
-        image = local.image_migrate
-
-        resources {
-          limits = {
-            cpu    = "1"
-            memory = "512Mi"
-          }
-        }
-
-        env {
-          name  = "DB_USER"
-          value = google_sql_user.app.name
-        }
-
-        env {
-          name  = "DB_NAME"
-          value = google_sql_database.app.name
-        }
-
-        env {
-          name  = "DB_CONNECTION_NAME"
-          value = google_sql_database_instance.main.connection_name
-        }
-
-        env {
-          name = "DB_PASSWORD"
-          value_source {
-            secret_key_ref {
-              secret  = google_secret_manager_secret.db_password.secret_id
-              version = "latest"
-            }
-          }
-        }
-
-        volume_mounts {
-          name       = "cloudsql"
-          mount_path = "/cloudsql"
-        }
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
       }
     }
   }
@@ -310,4 +314,9 @@ output "api_url" {
 output "worker_url" {
   value       = google_cloud_run_v2_service.worker.uri
   description = "Worker Function の URL（Cloud Scheduler がトリガー）"
+}
+
+output "migrate_url" {
+  value       = google_cloud_run_v2_service.migrate.uri
+  description = "Migrate Function の URL（CI/CD が HTTP POST でトリガー）"
 }

--- a/infra/main/iam.tf
+++ b/infra/main/iam.tf
@@ -73,6 +73,15 @@ resource "google_cloud_run_v2_service_iam_member" "scheduler_worker_invoker" {
   member   = "serviceAccount:${google_service_account.scheduler.email}"
 }
 
+# Terraform CI/CD SA に migrate Service の invoker 権限を付与（CI からマイグレーション実行用）
+resource "google_cloud_run_v2_service_iam_member" "terraform_ci_migrate_invoker" {
+  project  = var.project_id
+  location = google_cloud_run_v2_service.migrate.location
+  name     = google_cloud_run_v2_service.migrate.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.terraform_ci.email}"
+}
+
 # Terraform CI/CD 用サービスアカウント（GitHub Actions WIF）
 resource "google_service_account" "terraform_ci" {
   account_id   = "terraform-ci-sa"


### PR DESCRIPTION
## Summary

- `google_cloud_run_v2_job.migrate` を `google_cloud_run_v2_service.migrate` に置換し、worker と同一の Cloud Run Service（Function）パターンに統一
- CI/CD から `gcloud run jobs execute` ではなく HTTP POST（OIDC 認証付き curl）でマイグレーションをトリガーする構成に変更
- `terraform_ci` SA に migrate Service の `roles/run.invoker` 権限を追加

## Changes

- `infra/main/cloudrun.tf`: Job → Service 置換、`migrate_url` output 追加
- `infra/main/iam.tf`: `terraform_ci_migrate_invoker` IAM バインディング追加
- `.github/workflows/migrate.yml`: `gcloud run jobs` → `gcloud run services update` + `curl POST $MIGRATE_URL/`
- `.github/workflows/tf-apply.yml`: MIGRATE_TAG 取得元を `run jobs describe` → `run services describe` に変更

## Test plan

- [ ] `tf-apply` ワークフローが `google_cloud_run_v2_service.migrate` を正常に apply できること
- [ ] `migrate.yml` ワークフローがイメージをビルド・push し、Service を更新できること
- [ ] `curl POST $MIGRATE_URL/` が HTTP 200 を返し、マイグレーションが完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
