### PR TITLE
fix: WIF環境でのIDトークン取得エラーを修正（migrate CI）

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -56,7 +56,10 @@ jobs:
             --region asia-northeast1 \
             --project ${{ vars.TF_PROJECT_ID }} \
             --format='value(status.url)')
-          TOKEN=$(gcloud auth print-identity-token --audiences="$MIGRATE_URL")
+          # WIF 認証では --audiences 単独指定が使えないため SA を明示的に impersonate してIDトークンを取得
+          TOKEN=$(gcloud auth print-identity-token \
+            --impersonate-service-account=${{ secrets.GCP_TERRAFORM_SA }} \
+            --audiences="$MIGRATE_URL")
           curl -sf -X POST \
             -H "Authorization: Bearer $TOKEN" \
             "$MIGRATE_URL/"

--- a/infra/main/iam.tf
+++ b/infra/main/iam.tf
@@ -145,6 +145,14 @@ resource "google_service_account_iam_member" "terraform_ci_wif" {
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
 }
 
+# terraform_ci SA の自己 IDトークン発行権限
+# WIF 経由で認証した状態から --impersonate-service-account で IDトークンを取得するために必要
+resource "google_service_account_iam_member" "terraform_ci_token_creator_self" {
+  service_account_id = google_service_account.terraform_ci.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.terraform_ci.email}"
+}
+
 # Terraform CI SA → cloudrun-sa / worker-sa の actAs 権限
 # Cloud Run Service/Job 作成時に service_account を指定するには
 # デプロイ主体が対象 SA に対して iam.serviceaccounts.actAs を持つ必要がある


### PR DESCRIPTION
## Summary

- `gcloud auth print-identity-token --audiences` は GitHub Actions の WIF（Workload Identity Federation）認証では動作しない（`Invalid account type for --audiences` エラー）
- `--impersonate-service-account` を付けて SA を明示的に指定することで IDトークンを取得するよう修正
- terraform_ci SA に自己 `serviceAccountTokenCreator` バインディングを追加（SAが自身のIDトークンを発行するために必要）

## Changes

- `.github/workflows/migrate.yml`: `--impersonate-service-account=${{ secrets.GCP_TERRAFORM_SA }}` を追加
- `infra/main/iam.tf`: `terraform_ci_token_creator_self` リソースを追加

## Test plan

- [ ] `migrate` ワークフローの `Run DB migration` ステップが `Invalid account type` エラーなく通過すること
- [ ] curl が HTTP 200 を返しマイグレーションが完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
