### PR TITLE
fix: FailJobがLyricChainのステータスを更新しない問題と有害コンテンツの不要なリトライを修正

### DIFF
--- a/backend/internal/domain/repository/lyria_job.go
+++ b/backend/internal/domain/repository/lyria_job.go
@@ -28,6 +28,8 @@ type LyriaJobRepository interface {
 	// CompleteJob はジョブを completed に更新し、生成楽曲を保存してチェーンを completed に更新する
 	CompleteJob(ctx context.Context, jobID, chainID string, song SaveSongInput) error
 
-	// FailJob はジョブ失敗を記録する。リトライ回数が閾値未満なら pending に戻す
-	FailJob(ctx context.Context, jobID string, errMsg string) error
+	// FailJob はジョブ失敗を記録する。permanent=true またはリトライ回数が閾値に達した場合は
+	// ジョブを failed に遷移させ、関連する LyricChain も failed に更新する。
+	// それ以外はリトライのため pending に戻す。
+	FailJob(ctx context.Context, jobID string, errMsg string, permanent bool) error
 }

--- a/backend/internal/infra/rdb/lyria_job_repository.go
+++ b/backend/internal/infra/rdb/lyria_job_repository.go
@@ -127,8 +127,10 @@ func (r *lyriaJobRepository) CompleteJob(ctx context.Context, jobID, chainID str
 	})
 }
 
-// FailJob はジョブ失敗を記録する。リトライ回数が閾値未満なら pending に戻す
-func (r *lyriaJobRepository) FailJob(ctx context.Context, jobID string, errMsg string) error {
+// FailJob はジョブ失敗を記録する。permanent=true またはリトライ回数が閾値に達した場合は
+// ジョブを failed に遷移させ、関連する LyricChain も failed に更新する。
+// それ以外はリトライのため pending に戻す。
+func (r *lyriaJobRepository) FailJob(ctx context.Context, jobID string, errMsg string, permanent bool) error {
 	now := time.Now().UTC()
 
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -141,8 +143,13 @@ func (r *lyriaJobRepository) FailJob(ctx context.Context, jobID string, errMsg s
 		job.ErrorMessage = &errMsg
 		job.ProcessedAt = &now
 
-		if job.RetryCount >= maxRetryCount {
+		if permanent || job.RetryCount >= maxRetryCount {
 			job.Status = "failed"
+			if err := tx.Model(&model.LyricChain{}).
+				Where("id = ?", job.ChainID).
+				Update("status", "failed").Error; err != nil {
+				return err
+			}
 		} else {
 			job.Status = "pending"
 		}

--- a/backend/internal/infra/rdb/lyria_job_repository_test.go
+++ b/backend/internal/infra/rdb/lyria_job_repository_test.go
@@ -213,7 +213,7 @@ func TestLyriaJobRepository_FailJob_Retry(t *testing.T) {
 	}
 
 	// 1回失敗 → pending に戻るはず
-	if err := repo.FailJob(context.Background(), jobID, "test error"); err != nil {
+	if err := repo.FailJob(context.Background(), jobID, "test error", false); err != nil {
 		t.Fatalf("FailJob: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestLyriaJobRepository_FailJob_MaxRetry(t *testing.T) {
 	sharedTestDB.Model(&model.OutboxLyriaJob{}).Where("id = ?", jobID).
 		Updates(map[string]any{"retry_count": maxRetryCount - 1, "status": "processing"})
 
-	if err := repo.FailJob(context.Background(), jobID, "final error"); err != nil {
+	if err := repo.FailJob(context.Background(), jobID, "final error", false); err != nil {
 		t.Fatalf("FailJob: %v", err)
 	}
 
@@ -250,5 +250,44 @@ func TestLyriaJobRepository_FailJob_MaxRetry(t *testing.T) {
 	sharedTestDB.First(&job, "id = ?", jobID)
 	if job.Status != "failed" {
 		t.Errorf("after max retry: expected failed, got %s", job.Status)
+	}
+
+	// LyricChain も failed に更新されているはず
+	var chain model.LyricChain
+	sharedTestDB.First(&chain, "id = ?", job.ChainID)
+	if chain.Status != "failed" {
+		t.Errorf("chain status after max retry: expected failed, got %s", chain.Status)
+	}
+}
+
+func TestLyriaJobRepository_FailJob_Permanent(t *testing.T) {
+	if sharedTestDB == nil {
+		t.Skip("postgres not available")
+	}
+
+	chainID, jobID := setupLyriaTestData(t)
+	repo := NewLyriaJobRepository(sharedTestDB)
+
+	// claim して processing にする
+	if _, err := repo.ClaimPendingJobs(context.Background(), 5); err != nil {
+		t.Fatalf("ClaimPendingJobs: %v", err)
+	}
+
+	// permanent=true で即座に failed になるはず (リトライ回数に関係なく)
+	if err := repo.FailJob(context.Background(), jobID, "harmful content", true); err != nil {
+		t.Fatalf("FailJob permanent: %v", err)
+	}
+
+	var job model.OutboxLyriaJob
+	sharedTestDB.First(&job, "id = ?", jobID)
+	if job.Status != "failed" {
+		t.Errorf("permanent fail: expected failed, got %s", job.Status)
+	}
+
+	// LyricChain も failed に更新されているはず
+	var chain model.LyricChain
+	sharedTestDB.First(&chain, "id = ?", chainID)
+	if chain.Status != "failed" {
+		t.Errorf("chain status on permanent fail: expected failed, got %s", chain.Status)
 	}
 }

--- a/backend/internal/usecase/worker.go
+++ b/backend/internal/usecase/worker.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,10 @@ import (
 	"hackathon/internal/domain/repository"
 	"hackathon/internal/usecase/port"
 )
+
+// ErrHarmfulContent は有害コンテンツ検出による永続的エラーを示す。
+// このエラーは歌詞の内容が原因であるため、リトライしても結果は変わらない。
+var ErrHarmfulContent = errors.New("harmful content detected")
 
 // SongUploader は音声ファイルのアップロードを担うインターフェース
 type SongUploader interface {
@@ -71,8 +76,9 @@ func (u *workerUsecase) ProcessLyriaJobs(ctx context.Context) (int, error) {
 	processed := 0
 	for _, job := range jobs {
 		if err := u.processJob(ctx, job); err != nil {
-			// FailJob はリトライ管理を行うため、エラーを記録して継続
-			_ = u.lyriaJobRepo.FailJob(ctx, job.JobID, err.Error())
+			// 有害コンテンツは歌詞が不変なため即座に永続失敗とし、不要なリトライを防ぐ
+			permanent := errors.Is(err, ErrHarmfulContent)
+			_ = u.lyriaJobRepo.FailJob(ctx, job.JobID, err.Error(), permanent)
 			continue
 		}
 		processed++
@@ -91,7 +97,7 @@ func (u *workerUsecase) processJob(ctx context.Context, job repository.OutboxLyr
 		return fmt.Errorf("moderation failed: %w", err)
 	}
 	if modResult.IsHarmful {
-		return fmt.Errorf("content moderation failed: harmful content detected (categories: %v)", modResult.Categories)
+		return fmt.Errorf("%w: categories: %v", ErrHarmfulContent, modResult.Categories)
 	}
 
 	// 歌詞分析

--- a/backend/internal/usecase/worker_lyria_test.go
+++ b/backend/internal/usecase/worker_lyria_test.go
@@ -12,10 +12,15 @@ import (
 
 // ─── スタブ実装 ───────────────────────────────────────────────────────────────
 
+type failedJob struct {
+	jobID     string
+	permanent bool
+}
+
 type stubLyriaJobRepo struct {
 	pendingJobs []repository.OutboxLyriaJobDetail
 	completed   []repository.SaveSongInput
-	failed      []string // FailJob で記録された jobID
+	failed      []failedJob // FailJob で記録された jobID と permanent フラグ
 }
 
 func (r *stubLyriaJobRepo) ClaimPendingJobs(_ context.Context, _ int) ([]repository.OutboxLyriaJobDetail, error) {
@@ -27,8 +32,8 @@ func (r *stubLyriaJobRepo) CompleteJob(_ context.Context, _, _ string, song repo
 	return nil
 }
 
-func (r *stubLyriaJobRepo) FailJob(_ context.Context, jobID string, _ string) error {
-	r.failed = append(r.failed, jobID)
+func (r *stubLyriaJobRepo) FailJob(_ context.Context, jobID string, _ string, permanent bool) error {
+	r.failed = append(r.failed, failedJob{jobID: jobID, permanent: permanent})
 	return nil
 }
 
@@ -167,8 +172,11 @@ func TestProcessLyriaJobs_HarmfulContent(t *testing.T) {
 	if processed != 0 {
 		t.Errorf("expected 0 processed (harmful content), got %d", processed)
 	}
-	if len(jobRepo.failed) != 1 || jobRepo.failed[0] != "job-harmful" {
+	if len(jobRepo.failed) != 1 || jobRepo.failed[0].jobID != "job-harmful" {
 		t.Errorf("expected job-harmful to be failed, got %v", jobRepo.failed)
+	}
+	if !jobRepo.failed[0].permanent {
+		t.Error("expected harmful content job to be permanently failed (permanent=true)")
 	}
 }
 
@@ -197,6 +205,9 @@ func TestProcessLyriaJobs_LyriaError(t *testing.T) {
 	}
 	if len(jobRepo.failed) != 1 {
 		t.Errorf("expected 1 failed job, got %v", jobRepo.failed)
+	}
+	if jobRepo.failed[0].permanent {
+		t.Error("expected transient error job to not be permanently failed (permanent=false)")
 	}
 }
 


### PR DESCRIPTION
- FailJob に permanent bool パラメータを追加し、インターフェース・実装・テストを更新
- maxRetryCount 到達時または permanent=true 時に LyricChain.status を "failed" に更新し、 ユーザーがチェーンを「生成中」のまま永久に見続ける問題を解消
- 有害コンテンツ検出時は ErrHarmfulContent (sentinel error) でラップして返し、 ProcessLyriaJobs で errors.Is により permanent=true で FailJob を呼ぶことで 同じ歌詞に対する不要な Gemini API 呼び出し (最大3回) を排除

https://claude.ai/code/session_01TCkXtDqHmm4kuhgbAxJ7t5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
