### PR TITLE
fix: FailJob にデタッチドコンテキストを使用してジョブのスタックを防ぐ

### DIFF
--- a/backend/internal/usecase/worker.go
+++ b/backend/internal/usecase/worker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -78,7 +79,11 @@ func (u *workerUsecase) ProcessLyriaJobs(ctx context.Context) (int, error) {
 		if err := u.processJob(ctx, job); err != nil {
 			// 有害コンテンツは歌詞が不変なため即座に永続失敗とし、不要なリトライを防ぐ
 			permanent := errors.Is(err, ErrHarmfulContent)
-			_ = u.lyriaJobRepo.FailJob(ctx, job.JobID, err.Error(), permanent)
+			// ctx がキャンセル済みの場合（Cloud Run タイムアウト等）でも FailJob を確実に実行するため、
+			// デタッチドコンテキストにタイムアウトを付けて使用する。
+			failCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = u.lyriaJobRepo.FailJob(failCtx, job.JobID, err.Error(), permanent)
+			cancel()
 			continue
 		}
 		processed++


### PR DESCRIPTION
HTTP リクエストコンテキスト（ctx）がキャンセルされた場合（Cloud Run タイムアウト等）、 processJob がキャンセルエラーで失敗した後に同じキャンセル済み ctx で FailJob を呼び出すと DB 更新も失敗し、ジョブが "processing" ステータスのまま永久にスタックしていた。

FailJob 呼び出し時に context.Background() に 10 秒のタイムアウトを付けた新しいコンテキストを 使用することで、元の HTTP コンテキストがキャンセルされてもジョブの失敗状態を確実に記録できるようにした。

https://claude.ai/code/session_019ewqBavfdnA4zn8XJXduaV
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
