### PR TITLE
fix: 本番環境で AUDIO_BUCKET_NAME が未設定の場合に起動時エラーを発生させる

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -81,6 +81,9 @@ func LoadWorker() (*WorkerConfig, error) {
 			cfg.DBConnectionName,
 		)
 	}
+	if cfg.GoEnv != "development" && cfg.VertexAIProjectID != "" && cfg.AudioBucketName == "" {
+		return nil, fmt.Errorf("AUDIO_BUCKET_NAME は本番環境で VERTEX_AI_PROJECT_ID が設定されている場合は必須です")
+	}
 	return &cfg, nil
 }
 


### PR DESCRIPTION
VertexAIProjectID が設定されている本番環境において AudioBucketName が空の場合、 LoadWorker() でエラーを返すバリデーションを追加。
これにより、AUDIO_BUCKET_NAME 未設定時にサイレントに起動して全 Lyria ジョブが 失敗するという問題を起動時に検出できるようになる。

https://claude.ai/code/session_01Bu8Rf1Vp3kAxZuudAp58h1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
