### PR TITLE
fix: Gemini・Lyria・Storage の gRPC クライアントの Close() を追加しリソースリークを修正

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -43,7 +43,8 @@ func main() {
 	defer func() { _ = sqlDB.Close() }()
 
 	ctx := context.Background()
-	workerUsecase := buildDependencies(ctx, db, cfg, log)
+	workerUsecase, cleanup := buildDependencies(ctx, db, cfg, log)
+	defer cleanup()
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/backend/cmd/worker/wire.go
+++ b/backend/cmd/worker/wire.go
@@ -16,13 +16,14 @@ import (
 	"hackathon/internal/usecase/port"
 )
 
-func buildDependencies(ctx context.Context, db *gorm.DB, cfg *config.WorkerConfig, log *zap.Logger) usecase.WorkerUsecase {
+func buildDependencies(ctx context.Context, db *gorm.DB, cfg *config.WorkerConfig, log *zap.Logger) (usecase.WorkerUsecase, func()) {
 	bleTokenRepo := rdb.NewBleTokenRepository(db)
 	lyriaJobRepo := rdb.NewLyriaJobRepository(db)
 
 	var geminiClient port.GeminiClient
 	var lyriaClient port.LyriaClient
 	var songUploader usecase.SongUploader
+	var cleanup func()
 
 	// 開発環境またはプロジェクトID未設定時はモッククライアントを使用
 	if cfg.GoEnv == "development" || cfg.VertexAIProjectID == "" {
@@ -30,24 +31,37 @@ func buildDependencies(ctx context.Context, db *gorm.DB, cfg *config.WorkerConfi
 		geminiClient = newMockGeminiClient()
 		lyriaClient = infralyria.NewMockClient()
 		songUploader = newMockSongUploader()
+		cleanup = func() {}
 	} else {
-		var err error
-
-		geminiClient, err = infragemini.NewClient(ctx, cfg.VertexAIProjectID, cfg.VertexAILocation, cfg.GeminiModelID)
+		realGeminiClient, err := infragemini.NewClient(ctx, cfg.VertexAIProjectID, cfg.VertexAILocation, cfg.GeminiModelID)
 		if err != nil {
 			log.Fatal("failed to create Gemini client", zap.Error(err))
 		}
+		geminiClient = realGeminiClient
 
-		lyriaClient, err = infralyria.NewClient(ctx, cfg.VertexAIProjectID, cfg.VertexAILocation, cfg.LyriaModelID)
+		realLyriaClient, err := infralyria.NewClient(ctx, cfg.VertexAIProjectID, cfg.VertexAILocation, cfg.LyriaModelID)
 		if err != nil {
 			log.Fatal("failed to create Lyria client", zap.Error(err))
 		}
+		lyriaClient = realLyriaClient
 
 		storageClient, err := infrastorage.NewClient(ctx, cfg.AudioBucketName)
 		if err != nil {
 			log.Fatal("failed to create Storage client", zap.Error(err))
 		}
 		songUploader = storageClient
+
+		cleanup = func() {
+			if err := realGeminiClient.Close(); err != nil {
+				log.Warn("failed to close Gemini client", zap.Error(err))
+			}
+			if err := realLyriaClient.Close(); err != nil {
+				log.Warn("failed to close Lyria client", zap.Error(err))
+			}
+			if err := storageClient.Close(); err != nil {
+				log.Warn("failed to close Storage client", zap.Error(err))
+			}
+		}
 	}
 
 	return usecase.NewWorkerUsecase(
@@ -57,7 +71,7 @@ func buildDependencies(ctx context.Context, db *gorm.DB, cfg *config.WorkerConfi
 		lyriaClient,
 		songUploader,
 		cfg.LyriaDefaultDuration,
-	)
+	), cleanup
 }
 
 // mockGeminiClient は開発環境用のモック Gemini クライアント

--- a/backend/internal/infra/gemini/client.go
+++ b/backend/internal/infra/gemini/client.go
@@ -62,6 +62,11 @@ func cleanJSON(s string) string {
 	return strings.TrimSpace(s)
 }
 
+// Close は内部の gRPC 接続を閉じる
+func (c *Client) Close() error {
+	return c.client.Close()
+}
+
 // AnalyzeLyrics は歌詞を分析してムード・ジャンル等を推定する
 func (c *Client) AnalyzeLyrics(ctx context.Context, lyrics string) (*port.LyricsAnalysis, error) {
 	prompt := "以下の歌詞を分析してください。\n\n" +

--- a/backend/internal/infra/lyria/client.go
+++ b/backend/internal/infra/lyria/client.go
@@ -37,6 +37,11 @@ func NewClient(ctx context.Context, projectID, location, modelID string) (*Clien
 	}, nil
 }
 
+// Close は内部の gRPC 接続を閉じる
+func (c *Client) Close() error {
+	return c.prediction.Close()
+}
+
 // GenerateSong は歌詞とパラメータから楽曲を生成する
 func (c *Client) GenerateSong(ctx context.Context, req *port.LyriaRequest) (*port.LyriaResponse, error) {
 	prompt := c.buildPrompt(req)

--- a/backend/internal/infra/storage/client.go
+++ b/backend/internal/infra/storage/client.go
@@ -27,6 +27,11 @@ func NewClient(ctx context.Context, bucketName string) (*Client, error) {
 	}, nil
 }
 
+// Close は内部の gRPC 接続を閉じる
+func (c *Client) Close() error {
+	return c.gcs.Close()
+}
+
 // UploadSong は音声データを Cloud Storage にアップロードし、公開 URL を返す
 func (c *Client) UploadSong(ctx context.Context, chainID string, audioData []byte) (string, error) {
 	objectPath := fmt.Sprintf("songs/%s/original.wav", chainID)


### PR DESCRIPTION
- infragemini.Client, infralyria.Client, infrastorage.Client に Close() メソッドを追加
- buildDependencies の戻り値に cleanup 関数を追加し、本番クライアントの Close() を束ねる
- main.go で defer cleanup() を呼び出し、sqlDB.Close() と同様にシャットダウン時にクリーンアップされるようにした

https://claude.ai/code/session_01HmvHTy2oZC5sYt6mqPnhfa
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
