### PR TITLE
debug: Spotify callback エラーをログ出力

### DIFF
--- a/backend/internal/handler/music.go
+++ b/backend/internal/handler/music.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -70,6 +71,7 @@ func (h *musicHandler) callback(c echo.Context) error {
 	if err := h.musicUsecase.HandleCallback(c.Request().Context(), provider, code, state); err != nil {
 		result = "error"
 		errorCode = domainErrorCode(err)
+		log.Printf("[SPOTIFY_CALLBACK_ERROR] provider=%s code=%s error=%v", provider, code, err)
 	}
 	return c.Redirect(http.StatusFound, h.musicUsecase.CallbackRedirectURL(provider, result, errorCode))
 }


### PR DESCRIPTION
## 変更サマリー

- Spotify OAuth コールバックが失敗した際、エラー内容が Cloud Run ログに出力されていなかった（ハンドラが常に 302 redirect を返すため）
- `HandleCallback` でエラーが発生した場合に `log.Printf` でエラー内容を出力するよう追加した
- 影響レイヤー: backend / 認証フロー（デバッグ用途、動作変更なし）

## テスト方法

- [ ] Spotify 連携を試行し、Cloud Run ログに `[SPOTIFY_CALLBACK_ERROR]` が出力されることを確認する
- [ ] エラー内容をもとに根本原因を特定する

## 考慮事項

- このコミットはデバッグ用途であり、根本原因特定後に削除または適切なログレベルへの変更を検討する
- セキュリティ: ログに Spotify の authorization code が含まれる（Cloud Run ログは非公開のため許容範囲）
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
