### PR TITLE
fix: BlockUsecase の DI 設定漏れによる GET /users/me/blocks の 500 エラーを修正

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -68,6 +68,7 @@ func buildDependencies(db *gorm.DB, authClient *firebaseauth.Client, cfg *config
 		PlaylistUsecase:     usecase.NewPlaylistUsecase(playlistRepo, userRepo),
 		ReportUsecase:       usecase.NewReportUsecase(userRepo, reportRepo),
 		MuteUsecase:         usecase.NewMuteUsecase(userRepo, muteRepo),
+		BlockUsecase:        usecase.NewBlockUsecase(userRepo, blockRepo),
 		NotificationUsecase: usecase.NewNotificationUsecase(userRepo, notificationRepo),
 		MusicUsecase:        usecase.NewMusicUsecase(userRepo, musicConnectionRepo, trackCatalogRepo, []usecaseport.MusicProvider{spotifyProvider, appleMusicProvider}, cfg.MusicStateSecret, cfg.AppDeepLinkScheme),
 		EncounterUsecase:    usecase.NewEncounterUsecase(userRepo, bleTokenRepo, encounterRepo, blockRepo),


### PR DESCRIPTION
## 変更サマリー

- `wire.go` の `buildDependencies` 関数で `BlockUsecase` フィールドの設定が漏れていた。
- `handler.Dependencies.BlockUsecase` がゼロ値（nil インターフェース）のまま `blockHandler` に渡され、`h.usecase.ListBlocks()` 呼び出し時に nil pointer dereference パニックが発生していた。
- これが `GET /api/v1/users/me/blocks` で常に HTTP 500 が返る原因だった（DB クエリ未到達のためレスポンスタイムが 2ms 台）。
- 影響レイヤー: backend / DI 設定

## テスト方法

- [x] 既存の `TestListBlocks_*` テスト群が通ることを確認
- [ ] `GET /api/v1/users/me/blocks?limit=50` を実際に叩いて 200 が返ることを確認

## 考慮事項

- `BlockUsecase` 以外の Usecase は同様の漏れがないことを確認済み（他は全て設定済み）
- セキュリティ・パフォーマンス・後方互換性への影響なし
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
