### PR TITLE
fix: iOS BLE のバックグラウンド検出と状態復元を改善

### DIFF
--- a/ios/ios/Core/Services/BLE/BLEManager.swift
+++ b/ios/ios/Core/Services/BLE/BLEManager.swift
@@ -12,15 +12,13 @@ final class BLEManager: NSObject, ObservableObject {
         static let appServiceUUID = CBUUID(string: "00001234-0000-1000-8000-00805F9B34FB")
         static let tokenPrefixHex = "A17E1E50B1ECAFE0"
         static let rssiThreshold = -85
-        static let detectionCountThreshold = 2
+        static let foregroundDetectionCountThreshold = 2
+        static let backgroundDetectionCountThreshold = 1
         static let detectionWindow: TimeInterval = 30
         static let debounce: TimeInterval = 30
         static let cooldown: TimeInterval = 5 * 60
-        static let backgroundScanWindow: TimeInterval = 5
-        static let backgroundSleepInterval: TimeInterval = 10
-        static let longBackgroundThreshold: TimeInterval = 10 * 60
-        static let longBackgroundScanWindow: TimeInterval = 3
-        static let longBackgroundSleepInterval: TimeInterval = 30
+        static let centralRestoreIdentifier = "hackathon-ble-central"
+        static let peripheralRestoreIdentifier = "hackathon-ble-peripheral"
     }
 
     enum BLEState: Equatable {
@@ -48,8 +46,6 @@ final class BLEManager: NSObject, ObservableObject {
     private var shouldAdvertise = false
     private var shouldScan = false
     private var isForeground = true
-    private var enteredBackgroundAt: Date?
-    private var scanPolicyTask: Task<Void, Never>?
     private var lowPowerModeObserver: NSObjectProtocol?
     private var isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
     private var advertisedToken: String?
@@ -61,8 +57,16 @@ final class BLEManager: NSObject, ObservableObject {
 
     override init() {
         super.init()
-        centralManager = CBCentralManager(delegate: self, queue: .main)
-        peripheralManager = CBPeripheralManager(delegate: self, queue: .main)
+        centralManager = CBCentralManager(
+            delegate: self,
+            queue: .main,
+            options: [CBCentralManagerOptionRestoreIdentifierKey: Constants.centralRestoreIdentifier]
+        )
+        peripheralManager = CBPeripheralManager(
+            delegate: self,
+            queue: .main,
+            options: [CBPeripheralManagerOptionRestoreIdentifierKey: Constants.peripheralRestoreIdentifier]
+        )
         lowPowerModeObserver = NotificationCenter.default.addObserver(
             forName: .NSProcessInfoPowerStateDidChange,
             object: nil,
@@ -73,7 +77,6 @@ final class BLEManager: NSObject, ObservableObject {
     }
 
     deinit {
-        scanPolicyTask?.cancel()
         if let lowPowerModeObserver {
             NotificationCenter.default.removeObserver(lowPowerModeObserver)
         }
@@ -102,14 +105,11 @@ final class BLEManager: NSObject, ObservableObject {
 
     func stopScanning() {
         shouldScan = false
-        scanPolicyTask?.cancel()
-        scanPolicyTask = nil
         stopScanningRuntime()
     }
 
     func updateAppForegroundState(_ isForeground: Bool) {
         self.isForeground = isForeground
-        enteredBackgroundAt = isForeground ? nil : Date()
         reconfigureScanningPolicy()
     }
 
@@ -175,67 +175,32 @@ final class BLEManager: NSObject, ObservableObject {
         }
 
         let data: [String: Any] = [
-            CBAdvertisementDataServiceUUIDsKey: [Constants.appServiceUUID, tokenUUID],
-            CBAdvertisementDataIsConnectable: false
+            CBAdvertisementDataServiceUUIDsKey: [Constants.appServiceUUID, tokenUUID]
         ]
 
         peripheralManager.stopAdvertising()
         peripheralManager.startAdvertising(data)
-        isAdvertising = true
     }
 
     private func reconfigureScanningPolicy() {
-        scanPolicyTask?.cancel()
-        scanPolicyTask = nil
-
         guard shouldScan, !isLowPowerModeEnabled else {
             stopScanningRuntime()
             return
         }
 
-        if isForeground {
-            startScanningRuntimeIfPossible()
-            return
-        }
-
-        scanPolicyTask = Task { [weak self] in
-            await self?.runBackgroundOpportunisticLoop()
-        }
-    }
-
-    @MainActor
-    private func runBackgroundOpportunisticLoop() async {
-        while shouldScan, !isForeground, !isLowPowerModeEnabled, !Task.isCancelled {
-            let cadence = currentBackgroundCadence()
-
-            startScanningRuntimeIfPossible()
-            try? await Task.sleep(nanoseconds: UInt64(cadence.window * 1_000_000_000))
-
-            guard shouldScan, !isForeground, !isLowPowerModeEnabled, !Task.isCancelled else { break }
-            stopScanningRuntime()
-
-            try? await Task.sleep(nanoseconds: UInt64(cadence.sleep * 1_000_000_000))
-        }
-
-        if !isForeground || isLowPowerModeEnabled || !shouldScan {
-            stopScanningRuntime()
-        }
-    }
-
-    private func currentBackgroundCadence() -> (window: TimeInterval, sleep: TimeInterval) {
-        guard
-            let enteredBackgroundAt,
-            Date().timeIntervalSince(enteredBackgroundAt) >= Constants.longBackgroundThreshold
-        else {
-            return (Constants.backgroundScanWindow, Constants.backgroundSleepInterval)
-        }
-        return (Constants.longBackgroundScanWindow, Constants.longBackgroundSleepInterval)
+        startScanningRuntimeIfPossible()
     }
 
     private func handlePowerModeChange() {
         isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
         applyAdvertisingState()
         reconfigureScanningPolicy()
+    }
+
+    private func log(_ message: String) {
+        #if DEBUG
+        print("[BLEManager] \(message)")
+        #endif
     }
 
     private func makeAdvertisingPayload(token: String) -> AdvertisingPayload? {
@@ -264,10 +229,11 @@ final class BLEManager: NSObject, ObservableObject {
     }
 
     private func decodeToken(fromAdvertisementData advertisementData: [String: Any]) -> String? {
-        guard
-            let serviceUUIDs = advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID],
-            serviceUUIDs.contains(Constants.appServiceUUID)
-        else {
+        let primaryUUIDs = advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? []
+        let overflowUUIDs = advertisementData[CBAdvertisementDataOverflowServiceUUIDsKey] as? [CBUUID] ?? []
+        let serviceUUIDs = primaryUUIDs + overflowUUIDs
+
+        guard serviceUUIDs.contains(Constants.appServiceUUID) else {
             return nil
         }
 
@@ -297,6 +263,9 @@ final class BLEManager: NSObject, ObservableObject {
         // CoreBluetooth uses 127 as a sentinel for unavailable RSSI.
         guard rssiValue != 127 else { return false }
         guard rssiValue >= Constants.rssiThreshold else { return false }
+        let detectionThreshold = isForeground
+            ? Constants.foregroundDetectionCountThreshold
+            : Constants.backgroundDetectionCountThreshold
 
         let previousCounter = detectionCountsByToken[token]
         let nextCount: Int
@@ -306,7 +275,7 @@ final class BLEManager: NSObject, ObservableObject {
             nextCount = 1
         }
         detectionCountsByToken[token] = DetectionCounter(count: nextCount, windowStartedAt: now)
-        guard nextCount >= Constants.detectionCountThreshold else { return false }
+        guard nextCount >= detectionThreshold else { return false }
 
         if let last = debounceByToken[token], now.timeIntervalSince(last) < Constants.debounce {
             return false
@@ -331,6 +300,17 @@ final class BLEManager: NSObject, ObservableObject {
 extension BLEManager: CBCentralManagerDelegate {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         updateState(central.state)
+        reconfigureScanningPolicy()
+    }
+
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        log("Central state restored: \(dict.keys.sorted())")
+
+        if let restoredScanServices = dict[CBCentralManagerRestoredStateScanServicesKey] as? [CBUUID],
+           restoredScanServices.contains(Constants.appServiceUUID) {
+            shouldScan = true
+        }
+
         reconfigureScanningPolicy()
     }
 
@@ -362,12 +342,29 @@ private struct DetectionCounter {
 
 extension BLEManager: CBPeripheralManagerDelegate {
     func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
-        if error != nil {
+        if let error {
+            log("Advertising failed: \(error.localizedDescription)")
             isAdvertising = false
+            return
         }
+        isAdvertising = true
     }
 
     func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        applyAdvertisingState()
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, willRestoreState dict: [String: Any]) {
+        log("Peripheral state restored: \(dict.keys.sorted())")
+
+        if let restoredAdvertisement = dict[CBPeripheralManagerRestoredStateAdvertisementDataKey] as? [String: Any],
+           let restoredUUIDs = restoredAdvertisement[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID],
+           let restoredTokenUUID = restoredUUIDs.first(where: { $0 != Constants.appServiceUUID }) {
+            shouldAdvertise = true
+            advertisedTokenUUID = restoredTokenUUID
+            advertisedToken = decodeBackendToken(fromTokenUUID: restoredTokenUUID)
+        }
+
         applyAdvertisingState()
     }
 }

--- a/ios/iosTests/BLEManagerMinimalTests.swift
+++ b/ios/iosTests/BLEManagerMinimalTests.swift
@@ -61,6 +61,20 @@ final class BLEManagerMinimalTests: XCTestCase {
         XCTAssertEqual(sut._test_decodeToken(fromAdvertisementData: data), token)
     }
 
+    func test_decodeToken_extractsTokenUUIDFromOverflowServiceUUIDs() {
+        let token = "0011223344556677"
+        guard let payload = sut._test_makeAdvertisingPayload(token: token) else {
+            XCTFail("Expected payload")
+            return
+        }
+
+        let data: [String: Any] = [
+            CBAdvertisementDataOverflowServiceUUIDsKey: [BLEManager.Constants.appServiceUUID, payload.tokenUUID]
+        ]
+
+        XCTAssertEqual(sut._test_decodeToken(fromAdvertisementData: data), token)
+    }
+
     func test_shouldEmitDetection_filtersByRSSI() {
         let token = "0011223344556677"
         let now = Date(timeIntervalSince1970: 0)
@@ -75,6 +89,15 @@ final class BLEManagerMinimalTests: XCTestCase {
 
         XCTAssertFalse(sut._test_shouldEmitDetection(token: token, rssi: NSNumber(value: -70), now: now))
         XCTAssertTrue(sut._test_shouldEmitDetection(token: token, rssi: NSNumber(value: -70), now: now.addingTimeInterval(1)))
+    }
+
+    func test_shouldEmitDetection_inBackgroundRequiresSingleDetection() {
+        let token = "0011223344556677"
+        let now = Date(timeIntervalSince1970: 0)
+
+        sut.updateAppForegroundState(false)
+
+        XCTAssertTrue(sut._test_shouldEmitDetection(token: token, rssi: NSNumber(value: -70), now: now))
     }
 
     func test_shouldEmitDetection_resetsCountOutsideWindow() {


### PR DESCRIPTION
### 変更サマリー

- iOS の BLE 検出ポリシーを見直し、バックグラウンド時は 1 回の検出で通知対象に進めるようにした。
- これに合わせて、フォアグラウンドとバックグラウンドで検出しきい値を分離し、スキャン再構成ロジックを単純化した。
- CoreBluetooth の state restoration 用 identifier を追加し、復元時にスキャン・広告状態を引き継げるようにした。
- オーバーフロー service UUID からのトークン復元と、バックグラウンド検出しきい値のテストを追加した。
- 影響レイヤー: iOS / BLE

### ロジック変更の図解

```mermaid
flowchart TD
    A[App enters background] --> B[BLEManager keeps scan policy active]
    B --> C{Advertisement contains app service UUID?}
    C -- No --> D[Ignore]
    C -- Yes --> E[Decode token UUID from primary or overflow UUIDs]
    E --> F{Background?}
    F -- Yes --> G[Emit on first valid detection]
    F -- No --> H[Require repeated detections]
    G --> I[Apply debounce and cooldown]
    H --> I
    I --> J[Notify app]

    K[System restores BLE state] --> L[Restore scan/advertise intent from manager state]
    L --> B
```

### テスト方法

- [x] 単体テスト（Swift: XCTest）
- [ ] APIエンドポイントの入出力確認（OpenAPIスキーマとの整合性）
- [ ] 実機またはシミュレータでの手動確認（BLE・位置情報を含む場合は手順を明記）
- [ ] 外部連携の確認

補足:
- `ios/iosTests/BLEManagerMinimalTests.swift` にオーバーフロー service UUID とバックグラウンド検出しきい値のテストを追加。
- 実機でのバックグラウンド復元確認は未実施。

### 考慮事項

- バックグラウンドの検出感度を上げたため、ノイズ環境では誤検知が増える可能性がある。
- state restoration は OS の復元タイミングに依存するため、実機での継続検証が必要。
- セキュリティ・プライバシーへの新たな影響は想定していない。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
