### PR TITLE
chore: 起動ログに SEED_OTHER_USER_ID を出力する

### DIFF
--- a/backend/cmd/seed-demo/main.go
+++ b/backend/cmd/seed-demo/main.go
@@ -50,7 +50,7 @@ func main() {
 	if port == "" {
 		port = "8080"
 	}
-	log.Printf("listening on :%s (target user: %s)", port, targetUserID)
+	log.Printf("listening on :%s (target user: %s, other user: %s)", port, targetUserID, otherUserID)
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatalf("server failed: %v", err)
 	}


### PR DESCRIPTION
seed-demo の deploy を再トリガーするための変更。起動ログに other user ID も表示するよう修正。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
