### PR TITLE
fix: deploy ワークフローに seed-demo の Cloud Run デプロイ step を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,3 +79,11 @@ jobs:
             --image asia-northeast1-docker.pkg.dev/${{ vars.TF_PROJECT_ID }}/app/worker:${{ github.sha }} \
             --region asia-northeast1 \
             --project ${{ vars.TF_PROJECT_ID }}
+
+      - name: Deploy Cloud Run Service (seed-demo)
+        continue-on-error: true
+        run: |
+          gcloud run services update seed-demo \
+            --image asia-northeast1-docker.pkg.dev/${{ vars.TF_PROJECT_ID }}/app/seed-demo:${{ github.sha }} \
+            --region asia-northeast1 \
+            --project ${{ vars.TF_PROJECT_ID }}


### PR DESCRIPTION
seed-demo のイメージビルド後に Cloud Run へのデプロイ step が抜けていたため、常に1周遅れの古いイメージが動いていた問題を修正。api/worker と同様に `gcloud run services update` で新イメージを反映する。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
