### PR TITLE
fix: lyric投稿から生成曲の歌詞表示までバックエンドと接続

### DIFF
--- a/android/app/src/main/java/com/digix00/musicswapping/generated/docs/HackathonInternalHandlerSchemaResponseUserSong.md
+++ b/android/app/src/main/java/com/digix00/musicswapping/generated/docs/HackathonInternalHandlerSchemaResponseUserSong.md
@@ -5,8 +5,11 @@
 | Name | Type | Description | Notes |
 | ------------ | ------------- | ------------- | ------------- |
 | **audioUrl** | **kotlin.String** |  |  [optional] |
+| **chainId** | **kotlin.String** |  |  [optional] |
+| **durationSec** | **kotlin.Int** |  |  [optional] |
 | **generatedAt** | **kotlin.String** |  |  [optional] |
 | **id** | **kotlin.String** |  |  [optional] |
+| **mood** | **kotlin.String** |  |  [optional] |
 | **myLyric** | **kotlin.String** |  |  [optional] |
 | **participantCount** | **kotlin.Int** |  |  [optional] |
 | **title** | **kotlin.String** |  |  [optional] |

--- a/android/app/src/main/java/com/digix00/musicswapping/generated/src/main/kotlin/com/digix00/musicswapping/generated/models/HackathonInternalHandlerSchemaResponseUserSong.kt
+++ b/android/app/src/main/java/com/digix00/musicswapping/generated/src/main/kotlin/com/digix00/musicswapping/generated/models/HackathonInternalHandlerSchemaResponseUserSong.kt
@@ -24,8 +24,11 @@ import kotlinx.serialization.Contextual
  * 
  *
  * @param audioUrl 
+ * @param chainId 
+ * @param durationSec 
  * @param generatedAt 
  * @param id 
+ * @param mood 
  * @param myLyric 
  * @param participantCount 
  * @param title 
@@ -37,11 +40,20 @@ data class HackathonInternalHandlerSchemaResponseUserSong (
     @SerialName(value = "audio_url")
     val audioUrl: kotlin.String? = null,
 
+    @SerialName(value = "chain_id")
+    val chainId: kotlin.String? = null,
+
+    @SerialName(value = "duration_sec")
+    val durationSec: kotlin.Int? = null,
+
     @SerialName(value = "generated_at")
     val generatedAt: kotlin.String? = null,
 
     @SerialName(value = "id")
     val id: kotlin.String? = null,
+
+    @SerialName(value = "mood")
+    val mood: kotlin.String? = null,
 
     @SerialName(value = "my_lyric")
     val myLyric: kotlin.String? = null,

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -5020,10 +5020,19 @@ const docTemplate = `{
                 "audio_url": {
                     "type": "string"
                 },
+                "chain_id": {
+                    "type": "string"
+                },
+                "duration_sec": {
+                    "type": "integer"
+                },
                 "generated_at": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "mood": {
                     "type": "string"
                 },
                 "my_lyric": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5014,10 +5014,19 @@
                 "audio_url": {
                     "type": "string"
                 },
+                "chain_id": {
+                    "type": "string"
+                },
+                "duration_sec": {
+                    "type": "integer"
+                },
                 "generated_at": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "mood": {
                     "type": "string"
                 },
                 "my_lyric": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -990,9 +990,15 @@ definitions:
     properties:
       audio_url:
         type: string
+      chain_id:
+        type: string
+      duration_sec:
+        type: integer
       generated_at:
         type: string
       id:
+        type: string
+      mood:
         type: string
       my_lyric:
         type: string

--- a/backend/internal/handler/schema/response/song.go
+++ b/backend/internal/handler/schema/response/song.go
@@ -7,8 +7,11 @@ type ListUserSongsResponse struct {
 
 type UserSong struct {
 	ID               string  `json:"id"`
+	ChainID          string  `json:"chain_id"`
 	Title            *string `json:"title,omitempty"`
 	AudioURL         *string `json:"audio_url,omitempty"`
+	DurationSec      *int    `json:"duration_sec,omitempty"`
+	Mood             *string `json:"mood,omitempty"`
 	ParticipantCount int     `json:"participant_count"`
 	MyLyric          string  `json:"my_lyric"`
 	GeneratedAt      *string `json:"generated_at,omitempty"`

--- a/backend/internal/handler/song.go
+++ b/backend/internal/handler/song.go
@@ -50,8 +50,11 @@ func (h *songHandler) listMySongs(c echo.Context) error {
 	for _, s := range result.Songs {
 		songs = append(songs, schemares.UserSong{
 			ID:               s.ID,
+			ChainID:          s.ChainID,
 			Title:            s.Title,
 			AudioURL:         s.AudioURL,
+			DurationSec:      s.DurationSec,
+			Mood:             s.Mood,
 			ParticipantCount: s.ParticipantCount,
 			MyLyric:          s.MyLyric,
 			GeneratedAt:      s.GeneratedAt,

--- a/backend/internal/usecase/dto/lyric.go
+++ b/backend/internal/usecase/dto/lyric.go
@@ -62,8 +62,11 @@ type ChainDetailResult struct {
 
 type UserSongDTO struct {
 	ID               string
+	ChainID          string
 	Title            *string
 	AudioURL         *string
+	DurationSec      *int
+	Mood             *string
 	ParticipantCount int
 	MyLyric          string
 	GeneratedAt      *string

--- a/backend/internal/usecase/song.go
+++ b/backend/internal/usecase/song.go
@@ -51,8 +51,11 @@ func (u *songUsecase) ListMySongs(ctx context.Context, authUID string, cursor st
 		}
 		dtos = append(dtos, usecasedto.UserSongDTO{
 			ID:               s.Song.ID,
+			ChainID:          s.Song.ChainID,
 			Title:            s.Song.Title,
 			AudioURL:         s.Song.AudioURL,
+			DurationSec:      s.Song.DurationSec,
+			Mood:             s.Song.Mood,
 			ParticipantCount: s.ParticipantCount,
 			MyLyric:          s.MyLyric,
 			GeneratedAt:      generatedAt,

--- a/ios/ios/Core/Services/Backend/BackendAPIModels.swift
+++ b/ios/ios/Core/Services/Backend/BackendAPIModels.swift
@@ -795,19 +795,7 @@ nonisolated struct BackendListUserSongsResponse: Decodable {
 }
 
 nonisolated struct BackendLikeSongResponse: Decodable {
-    let like: BackendLikeSongDetail
-}
-
-nonisolated struct BackendLikeSongDetail: Decodable {
-    let songId: String?
     let liked: Bool
-    let createdAt: Date?
-
-    enum CodingKeys: String, CodingKey {
-        case songId = "song_id"
-        case liked
-        case createdAt = "created_at"
-    }
 }
 
 // MARK: - Requests

--- a/ios/ios/Generated/Sources/OpenAPIClient/Models/HackathonInternalHandlerSchemaResponseUserSong.swift
+++ b/ios/ios/Generated/Sources/OpenAPIClient/Models/HackathonInternalHandlerSchemaResponseUserSong.swift
@@ -13,16 +13,22 @@ import AnyCodable
 public struct HackathonInternalHandlerSchemaResponseUserSong: Codable, JSONEncodable, Hashable {
 
     public var audioUrl: String?
+    public var chainId: String?
+    public var durationSec: Int?
     public var generatedAt: String?
     public var id: String?
+    public var mood: String?
     public var myLyric: String?
     public var participantCount: Int?
     public var title: String?
 
-    public init(audioUrl: String? = nil, generatedAt: String? = nil, id: String? = nil, myLyric: String? = nil, participantCount: Int? = nil, title: String? = nil) {
+    public init(audioUrl: String? = nil, chainId: String? = nil, durationSec: Int? = nil, generatedAt: String? = nil, id: String? = nil, mood: String? = nil, myLyric: String? = nil, participantCount: Int? = nil, title: String? = nil) {
         self.audioUrl = audioUrl
+        self.chainId = chainId
+        self.durationSec = durationSec
         self.generatedAt = generatedAt
         self.id = id
+        self.mood = mood
         self.myLyric = myLyric
         self.participantCount = participantCount
         self.title = title
@@ -30,8 +36,11 @@ public struct HackathonInternalHandlerSchemaResponseUserSong: Codable, JSONEncod
 
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case audioUrl = "audio_url"
+        case chainId = "chain_id"
+        case durationSec = "duration_sec"
         case generatedAt = "generated_at"
         case id
+        case mood
         case myLyric = "my_lyric"
         case participantCount = "participant_count"
         case title
@@ -42,8 +51,11 @@ public struct HackathonInternalHandlerSchemaResponseUserSong: Codable, JSONEncod
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(audioUrl, forKey: .audioUrl)
+        try container.encodeIfPresent(chainId, forKey: .chainId)
+        try container.encodeIfPresent(durationSec, forKey: .durationSec)
         try container.encodeIfPresent(generatedAt, forKey: .generatedAt)
         try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(mood, forKey: .mood)
         try container.encodeIfPresent(myLyric, forKey: .myLyric)
         try container.encodeIfPresent(participantCount, forKey: .participantCount)
         try container.encodeIfPresent(title, forKey: .title)

--- a/ios/ios/Generated/docs/HackathonInternalHandlerSchemaResponseUserSong.md
+++ b/ios/ios/Generated/docs/HackathonInternalHandlerSchemaResponseUserSong.md
@@ -4,8 +4,11 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **audioUrl** | **String** |  | [optional] 
+**chainId** | **String** |  | [optional] 
+**durationSec** | **Int** |  | [optional] 
 **generatedAt** | **String** |  | [optional] 
 **id** | **String** |  | [optional] 
+**mood** | **String** |  | [optional] 
 **myLyric** | **String** |  | [optional] 
 **participantCount** | **Int** |  | [optional] 
 **title** | **String** |  | [optional] 


### PR DESCRIPTION
## 変更サマリー

- `GET /users/me/songs`（生成曲一覧）のレスポンスに `chain_id`・`duration_sec`・`mood` が欠落しており、iOS の `GeneratedSongDetailViewModel` が `chainId == nil` のまま歌詞取得をスキップしていた問題を修正した。
- これにより「すれ違い → 歌詞投稿 → チェーン参加 → 生成曲詳細で参加歌詞を確認」の一連のフローがバックエンドと正常に繋がる。
- あわせて、iOS の `BackendLikeSongResponse` がバックエンド実態 `{"liked": bool}` と異なる定義になっており、いいね操作後に毎回デコードエラーが発生していた問題も修正した。
- 影響レイヤー: backend (handler/usecase/dto) / iOS (BackendAPIModels)

## テスト方法

- [ ] 実機またはシミュレータで歌詞を投稿し、生成曲一覧に曲が表示されることを確認
- [ ] 生成曲の詳細画面を開き、参加者の歌詞一覧（`getLyricChainDetail`）が表示されることを確認
- [ ] いいねボタンを押しても「いいねの更新に失敗しました」が表示されないことを確認
- [ ] `GET /users/me/songs` のレスポンスに `chain_id`・`duration_sec`・`mood` が含まれることを確認

## 考慮事項

- `liked` フィールドは今回スコープ外。iOS は `Bool?` でデフォルト `false` にフォールバックするため表示上の影響はない。
- バックエンドの後方互換性: レスポンスへのフィールド追加のみで既存フィールドの変更はなし。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
