### PR TITLE
fix: エンカウンター・インサイト画面でジャケ写が表示されないバグを修正

### DIFF
--- a/ios/ios/App/BLEAppCoordinator.swift
+++ b/ios/ios/App/BLEAppCoordinator.swift
@@ -455,7 +455,7 @@ final class BLEAppCoordinator: ObservableObject {
             title: item.title,
             artist: item.artistName,
             color: colorSeed(for: item.title + item.artistName),
-            artwork: nil
+            artwork: item.artworkURL
         )
     }
 


### PR DESCRIPTION
## 変更サマリー

- `BLEAppCoordinator.makeTrack()` 内で `artwork: nil` とハードコードされており、バックエンドAPIから返却される `artworkURL` が捨てられていた
- `artwork: item.artworkURL` に修正し、Encounter画面・Insight画面の両方でジャケ写が正しく表示されるようにした
- 影響レイヤー: iOS / `BLEAppCoordinator`

## テスト方法

- [ ] 実機またはシミュレータでEncounter画面を開き、楽曲のジャケ写が表示されることを確認
- [ ] Insight画面を開き、各セクションのジャケ写が表示されることを確認

## 考慮事項

- `artworkURL` が `nil` の場合は既存の `ArtworkPlaceholderView` のグラデーションプレースホルダーにフォールバックするため、後方互換性への影響なし
- `EncounterListViewModel.mapTrack()` は元々 `artwork: track.artworkURL` と正しく実装されていたが、`EncounterListScreen` は `EncounterListViewModel` ではなく `bleCoordinator.encounters` を参照しているため、こちらの修正が必要だった
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/digix00/hackathon/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
